### PR TITLE
feat(gameday): render header unconditionally and show Create Lineup CTA for scorekeepers

### DIFF
--- a/app/components/AchievementCard/AchievementCard.jsx
+++ b/app/components/AchievementCard/AchievementCard.jsx
@@ -78,7 +78,9 @@ export default function AchievementCard({
             style={{ "--rarity-color": rarityColor }}
             data-testid="achievement-card"
         >
-            <Box className={`${classes.haloContainer} ${hasSpecialEffect && !isLocked ? classes.haloContainerWithEffect : ""}`}>
+            <Box
+                className={`${classes.haloContainer} ${hasSpecialEffect && !isLocked ? classes.haloContainerWithEffect : ""}`}
+            >
                 {!isLocked && hasSpecialEffect && (
                     <Box className={classes.halo} />
                 )}
@@ -103,7 +105,10 @@ export default function AchievementCard({
                                     size="sm"
                                     radius="sm"
                                     leftSection={<IconTrophy size={10} />}
-                                    style={{ textTransform: "uppercase", fontSize: "10px" }}
+                                    style={{
+                                        textTransform: "uppercase",
+                                        fontSize: "10px",
+                                    }}
                                     data-testid="achievement-rarity-badge"
                                 >
                                     {rarity}
@@ -119,11 +124,23 @@ export default function AchievementCard({
                                     style={{
                                         textTransform: "uppercase",
                                         fontSize: "9px",
-                                        flexShrink: 0
+                                        flexShrink: 0,
                                     }}
                                     data-testid="achievement-player-badge"
                                 >
-                                    {isMe && <Box component="span" mr={4} style={{ display: 'inline-block', width: 4, height: 4, borderRadius: '50%', background: 'currentColor' }} />}
+                                    {isMe && (
+                                        <Box
+                                            component="span"
+                                            mr={4}
+                                            style={{
+                                                display: "inline-block",
+                                                width: 4,
+                                                height: 4,
+                                                borderRadius: "50%",
+                                                background: "currentColor",
+                                            }}
+                                        />
+                                    )}
                                     {playerName}
                                 </Badge>
                             )}
@@ -137,9 +154,13 @@ export default function AchievementCard({
                                 variant={isLocked ? "light" : "filled"}
                                 className={classes.icon}
                                 style={{
-                                    backgroundColor: isLocked ? "transparent" : `${rarityColor}15`,
+                                    backgroundColor: isLocked
+                                        ? "transparent"
+                                        : `${rarityColor}15`,
                                     color: isLocked ? "gray" : rarityColor,
-                                    border: isLocked ? "1px dashed var(--mantine-color-gray-6)" : `1px solid ${rarityColor}30`,
+                                    border: isLocked
+                                        ? "1px dashed var(--mantine-color-gray-6)"
+                                        : `1px solid ${rarityColor}30`,
                                 }}
                             >
                                 <IconElement size={24} stroke={1.5} />
@@ -149,13 +170,19 @@ export default function AchievementCard({
                                 <Text
                                     fw={800}
                                     size="lg"
-                                    className={isLocked ? classes.titleLocked : classes.title}
+                                    className={
+                                        isLocked
+                                            ? classes.titleLocked
+                                            : classes.title
+                                    }
                                     style={{ lineHeight: 1.2 }}
                                 >
                                     {name}
                                 </Text>
                                 <Text size="sm" className={classes.description}>
-                                    {isLocked ? "Keep playing to unlock this achievement." : description}
+                                    {isLocked
+                                        ? "Keep playing to unlock this achievement."
+                                        : description}
                                 </Text>
                             </Stack>
                         </Group>
@@ -164,9 +191,15 @@ export default function AchievementCard({
                         {!isLocked && (
                             <Box className={classes.innerBox}>
                                 <Group justify="space-between" align="center">
-                                    <Text className={classes.statLabel}>Unlocked</Text>
+                                    <Text className={classes.statLabel}>
+                                        Unlocked
+                                    </Text>
                                     <Text className={classes.statValue}>
-                                        {unlockedAt ? DateTime.fromISO(unlockedAt).toFormat("LLL dd, yyyy") : "---"}
+                                        {unlockedAt
+                                            ? DateTime.fromISO(
+                                                  unlockedAt,
+                                              ).toFormat("LLL dd, yyyy")
+                                            : "---"}
                                     </Text>
                                 </Group>
                             </Box>
@@ -180,7 +213,13 @@ export default function AchievementCard({
     // If it's locked, perhaps show the actual description in a tooltip instead
     if (isLocked) {
         return (
-            <Tooltip label={description} position="top" withArrow multiline w={250}>
+            <Tooltip
+                label={description}
+                position="top"
+                withArrow
+                multiline
+                w={250}
+            >
                 {content}
             </Tooltip>
         );

--- a/app/components/AchievementCard/AchievementCard.module.css
+++ b/app/components/AchievementCard/AchievementCard.module.css
@@ -36,12 +36,14 @@
     left: -50%;
     width: 200%;
     height: 200%;
-    background: conic-gradient(from 0deg,
-            transparent 0%,
-            var(--rarity-color) 25%,
-            transparent 50%,
-            var(--rarity-color) 75%,
-            transparent 100%);
+    background: conic-gradient(
+        from 0deg,
+        transparent 0%,
+        var(--rarity-color) 25%,
+        transparent 50%,
+        var(--rarity-color) 75%,
+        transparent 100%
+    );
     animation: rotate 4s cubic-bezier(0.5, 0.79, 0.71, 0.5) infinite;
     z-index: 1;
 }
@@ -49,20 +51,24 @@
 .card {
     position: relative;
     z-index: 2;
-    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+    transition:
+        border-color 0.3s ease,
+        box-shadow 0.3s ease;
 }
 
 .cardWithEffect {
     border-color: transparent !important;
-    box-shadow: 0 0 20px color-mix(in srgb, var(--rarity-color), transparent 85%);
+    box-shadow: 0 0 20px
+        color-mix(in srgb, var(--rarity-color), transparent 85%);
 }
 
 .root:hover .cardWithEffect {
-    box-shadow: 0 10px 25px color-mix(in srgb, var(--rarity-color), transparent 70%);
+    box-shadow: 0 10px 25px
+        color-mix(in srgb, var(--rarity-color), transparent 70%);
 }
 
 .innerBox {
-    background-color: light-dark(var(--mantine-color-gray-1), #0A0E14);
+    background-color: light-dark(var(--mantine-color-gray-1), #0a0e14);
     border-radius: var(--mantine-radius-sm);
     padding: 6px 12px;
     margin-top: 8px;
@@ -85,7 +91,11 @@
 /* Fallback border for light mode if halo is too faint */
 @media (prefers-color-scheme: light) {
     .cardWithEffect {
-        border-color: color-mix(in srgb, var(--rarity-color), transparent 60%) !important;
+        border-color: color-mix(
+            in srgb,
+            var(--rarity-color),
+            transparent 60%
+        ) !important;
     }
 }
 

--- a/app/routes/events/components/AwardsDrawerContents.jsx
+++ b/app/routes/events/components/AwardsDrawerContents.jsx
@@ -1,6 +1,16 @@
 import { useEffect, useState, useMemo, useRef } from "react";
 
-import { Card, Center, Image, Stack, Text, SimpleGrid, Box, Alert, Tabs } from "@mantine/core";
+import {
+    Card,
+    Center,
+    Image,
+    Stack,
+    Text,
+    SimpleGrid,
+    Box,
+    Alert,
+    Tabs,
+} from "@mantine/core";
 import { Carousel } from "@mantine/carousel";
 import { IconTrophy } from "@tabler/icons-react";
 
@@ -129,49 +139,52 @@ export default function AwardsDrawerContents({
         </Stack>
     );
 
-    const achievementsContent = validAchievements.length > 0 ? (
-        <Stack mt="md" gap="md">
-            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
-                {validAchievements.map((ua) => {
-                    const player = (players || []).find(p => p.$id === ua.userId);
-                    const playerName = player
-                        ? [player.firstName, player.lastName].filter(Boolean).join(" ").trim() || "Player"
-                        : "Player";
-                    const isMe = ua.userId === user?.$id;
+    const achievementsContent =
+        validAchievements.length > 0 ? (
+            <Stack mt="md" gap="md">
+                <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+                    {validAchievements.map((ua) => {
+                        const player = (players || []).find(
+                            (p) => p.$id === ua.userId,
+                        );
+                        const playerName = player
+                            ? [player.firstName, player.lastName]
+                                  .filter(Boolean)
+                                  .join(" ")
+                                  .trim() || "Player"
+                            : "Player";
+                        const isMe = ua.userId === user?.$id;
 
-                    return (
-                        <AchievementCard
-                            key={ua.$id}
-                            achievement={ua.achievement}
-                            unlockedAt={ua.$createdAt}
-                            playerName={isMe ? "YOU" : playerName}
-                            isMe={isMe}
-                        />
-                    );
-                })}
-            </SimpleGrid>
-        </Stack>
-    ) : (
-        <Box py="xl">
-            <Alert
-                icon={<IconTrophy size={16} />}
-                title="No Achievements Earned"
-                color="gray"
-                radius="md"
-            >
-                No achievements were unlocked in this game. Keep playing to earn trophies for you and your teammates!
-            </Alert>
-        </Box>
-    );
-
-
+                        return (
+                            <AchievementCard
+                                key={ua.$id}
+                                achievement={ua.achievement}
+                                unlockedAt={ua.$createdAt}
+                                playerName={isMe ? "YOU" : playerName}
+                                isMe={isMe}
+                            />
+                        );
+                    })}
+                </SimpleGrid>
+            </Stack>
+        ) : (
+            <Box py="xl">
+                <Alert
+                    icon={<IconTrophy size={16} />}
+                    title="No Achievements Earned"
+                    color="gray"
+                    radius="md"
+                >
+                    No achievements were unlocked in this game. Keep playing to
+                    earn trophies for you and your teammates!
+                </Alert>
+            </Box>
+        );
 
     return (
         <TabsWrapper defaultValue="awards" mt="xs">
             <Tabs.Tab value="awards">Voting & Awards</Tabs.Tab>
-            <Tabs.Tab value="achievements">
-                Achievements
-            </Tabs.Tab>
+            <Tabs.Tab value="achievements">Achievements</Tabs.Tab>
 
             <Tabs.Panel value="awards" pt="md">
                 {awardsContent}

--- a/app/routes/events/components/tests/AwardsDrawerContents.test.jsx
+++ b/app/routes/events/components/tests/AwardsDrawerContents.test.jsx
@@ -80,50 +80,70 @@ describe("AwardsDrawerContents", () => {
 
     it("updates active award when carousel slide changes", async () => {
         renderComponent({ awards: { total: 0, rows: [] } });
- 
+
         // Initial state: activeAward = 'mvp' (first key in actual constant)
         const votesContainer = screen.getByTestId("votes-container");
         expect(votesContainer).toHaveAttribute("data-active-award", "mvp");
- 
+
         // Change slide to index 1 ('clutch' is the second key in actual constant)
         const slide1Button = screen.getByText("Slide 1");
         fireEvent.click(slide1Button);
- 
+
         // Verify prop update
         expect(votesContainer).toHaveAttribute("data-active-award", "clutch");
     });
- 
+
     it("renders both Voting and Achievements tabs", () => {
         const mockAchievements = [
-            { $id: "ua1", achievement: { name: "Legendary Win", rarity: "Legendary" }, $createdAt: "2024-01-01" },
-            { $id: "ua2", achievement: { name: "Rare Hit", rarity: "Rare" }, $createdAt: "2024-01-01" }
+            {
+                $id: "ua1",
+                achievement: { name: "Legendary Win", rarity: "Legendary" },
+                $createdAt: "2024-01-01",
+            },
+            {
+                $id: "ua2",
+                achievement: { name: "Rare Hit", rarity: "Rare" },
+                $createdAt: "2024-01-01",
+            },
         ];
         renderComponent({ achievements: mockAchievements });
- 
+
         expect(screen.getByText("Voting & Awards")).toBeInTheDocument();
         expect(screen.getByText("Achievements")).toBeInTheDocument();
     });
- 
+
     it("sorts achievements by rarity (Legendary above Rare)", () => {
         const mockAchievements = [
-            { $id: "ua2", userId: "user1", achievement: { name: "Rare Hit", rarity: "Rare" }, $createdAt: "2024-01-01" },
-            { $id: "ua1", userId: "user1", achievement: { name: "Legendary Win", rarity: "Legendary" }, $createdAt: "2024-01-01" }
+            {
+                $id: "ua2",
+                userId: "user1",
+                achievement: { name: "Rare Hit", rarity: "Rare" },
+                $createdAt: "2024-01-01",
+            },
+            {
+                $id: "ua1",
+                userId: "user1",
+                achievement: { name: "Legendary Win", rarity: "Legendary" },
+                $createdAt: "2024-01-01",
+            },
         ];
         renderComponent({ achievements: mockAchievements });
- 
+
         // Click Achievements tab
         fireEvent.click(screen.getByText("Achievements"));
- 
+
         const titles = screen.getAllByText(/Legendary Win|Rare Hit/);
         // Legendary should be first due to weights (Legendary: 5, Rare: 3)
         expect(titles[0]).toHaveTextContent("Legendary Win");
         expect(titles[1]).toHaveTextContent("Rare Hit");
     });
- 
+
     it("shows empty state alert in Achievements tab when no trophies", () => {
         renderComponent({ achievements: [] });
- 
+
         fireEvent.click(screen.getByText("Achievements"));
-        expect(screen.getByText(/No achievements were unlocked in this game/i)).toBeInTheDocument();
+        expect(
+            screen.getByText(/No achievements were unlocked in this game/i),
+        ).toBeInTheDocument();
     });
 });

--- a/app/routes/gameday/components/DesktopGamedayContainer.jsx
+++ b/app/routes/gameday/components/DesktopGamedayContainer.jsx
@@ -1,6 +1,8 @@
 import { useState, useMemo } from "react";
+import { Link } from "react-router";
 import {
     Box,
+    Button,
     Card,
     Grid,
     Group,
@@ -97,19 +99,6 @@ export default function DesktopGamedayContainer({
         return idx > 0 ? logs[idx - 1] : null;
     }, [editLog, logs]);
 
-    if (playerChart.length === 0) {
-        return (
-            <Card p="xl" radius="lg" ta="center">
-                <Text fw={700} mb="xs">
-                    Lineup Required
-                </Text>
-                <Text size="sm" c="dimmed">
-                    You must create a lineup before scoring.
-                </Text>
-            </Card>
-        );
-    }
-
     const handleEditPlay = (log) => {
         setEditLog(log);
         openEditDrawer();
@@ -155,137 +144,163 @@ export default function DesktopGamedayContainer({
                 </Group>
             </Group>
 
-            <Box pos="relative">
-                <LoadingOverlay
-                    visible={isSyncing}
-                    overlayProps={{ radius: "lg", blur: 1, opacity: 0.1 }}
-                    loaderProps={{ color: "blue", type: "dots" }}
-                    zIndex={100}
-                />
+            {playerChart.length === 0 ? (
+                <Card p="xl" radius="lg" ta="center">
+                    <Text fw={700} mb="xs">
+                        Lineup Required
+                    </Text>
+                    <Text size="sm" c="dimmed" mb="md">
+                        You must create a lineup before scoring.
+                    </Text>
+                    {isScorekeeper && (
+                        <Button
+                            component={Link}
+                            to={`/events/${game.$id}/lineup`}
+                            variant="filled"
+                            color="lime"
+                            mt="xs"
+                        >
+                            Create Lineup
+                        </Button>
+                    )}
+                </Card>
+            ) : (
+                <Box pos="relative">
+                    <LoadingOverlay
+                        visible={isSyncing}
+                        overlayProps={{ radius: "lg", blur: 1, opacity: 0.1 }}
+                        loaderProps={{ color: "blue", type: "dots" }}
+                        zIndex={100}
+                    />
 
-                <Grid gutter="xl" mt="md" align="flex-start">
-                    {/* COLUMN 1: Matchup */}
-                    <Grid.Col span={{ base: 12, md: 4 }}>
-                        <Stack gap="md">
-                            <CompactMatchupCard
-                                score={score}
-                                opponentScore={opponentScore}
-                                inning={inning}
-                                halfInning={halfInning}
-                                outs={outs}
-                                teamName={team.name}
-                                opponentName={game.opponent}
-                                gameFinal={gameFinal}
-                                realtimeStatus={realtimeStatus}
-                                isOurBatting={isOurBatting}
-                                runners={runners}
-                                currentBatter={currentBatter}
-                                upcomingBatters={upcomingBatters}
-                                logs={logs}
-                            />
-                            {logs.length > 0 && isOurBatting && !gameFinal && (
-                                <LastPlayCard
-                                    lastLog={logs[logs.length - 1]}
-                                    onUndo={isScorekeeper ? undoLast : null}
-                                    isSubmitting={isSubmitting}
-                                    playerChart={playerChart}
+                    <Grid gutter="xl" mt="md" align="flex-start">
+                        {/* COLUMN 1: Matchup */}
+                        <Grid.Col span={{ base: 12, md: 4 }}>
+                            <Stack gap="md">
+                                <CompactMatchupCard
+                                    score={score}
+                                    opponentScore={opponentScore}
+                                    inning={inning}
+                                    halfInning={halfInning}
+                                    outs={outs}
+                                    teamName={team.name}
+                                    opponentName={game.opponent}
+                                    gameFinal={gameFinal}
+                                    realtimeStatus={realtimeStatus}
+                                    isOurBatting={isOurBatting}
+                                    runners={runners}
+                                    currentBatter={currentBatter}
+                                    upcomingBatters={upcomingBatters}
+                                    logs={logs}
                                 />
-                            )}
-                        </Stack>
-                    </Grid.Col>
+                                {logs.length > 0 &&
+                                    isOurBatting &&
+                                    !gameFinal && (
+                                        <LastPlayCard
+                                            lastLog={logs[logs.length - 1]}
+                                            onUndo={
+                                                isScorekeeper ? undoLast : null
+                                            }
+                                            isSubmitting={isSubmitting}
+                                            playerChart={playerChart}
+                                        />
+                                    )}
+                            </Stack>
+                        </Grid.Col>
 
-                    {/* COLUMN 2: Action Pad */}
-                    <Grid.Col span={{ base: 12, md: 4 }}>
-                        <Stack gap="md">
-                            {!gameFinal &&
-                                (isOurBatting ? (
-                                    isScorekeeper && (
-                                        <Card radius="lg">
-                                            <ActionPad
-                                                onAction={initiateAction}
-                                                runners={runners}
-                                                outs={outs}
+                        {/* COLUMN 2: Action Pad */}
+                        <Grid.Col span={{ base: 12, md: 4 }}>
+                            <Stack gap="md">
+                                {!gameFinal &&
+                                    (isOurBatting ? (
+                                        isScorekeeper && (
+                                            <Card radius="lg">
+                                                <ActionPad
+                                                    onAction={initiateAction}
+                                                    runners={runners}
+                                                    outs={outs}
+                                                />
+                                            </Card>
+                                        )
+                                    ) : (
+                                        <>
+                                            <DefenseCard
+                                                teamName={team.name}
+                                                dueUpBatters={dueUpBatters}
+                                            />
+                                            {isScorekeeper && (
+                                                <FieldingControls
+                                                    onOut={handleOpponentOut}
+                                                    onRun={handleOpponentRun}
+                                                    onSkip={advanceHalfInning}
+                                                />
+                                            )}
+                                        </>
+                                    ))}
+                            </Stack>
+                        </Grid.Col>
+
+                        {/* COLUMN 3: Tabs */}
+                        <Grid.Col span={{ base: 12, md: 4 }}>
+                            <TabsWrapper
+                                value={activeTab}
+                                onChange={(val) => handleTabChange(val)}
+                                mt={0}
+                                size="sm"
+                            >
+                                <Tabs.Tab value="plays">Plays</Tabs.Tab>
+                                <Tabs.Tab value="boxscore">Box Score</Tabs.Tab>
+                                <Tabs.Tab value="spray">Spray Chart</Tabs.Tab>
+                                {gameFinal && (
+                                    <Tabs.Tab value="achievements">
+                                        Achievements
+                                    </Tabs.Tab>
+                                )}
+
+                                <Tabs.Panel value="plays" pt="md">
+                                    <Stack gap="md">
+                                        <Card radius="md" p="xs">
+                                            <PlayHistoryList
+                                                logs={logs}
+                                                playerChart={playerChart}
+                                                isScorekeeper={isScorekeeper}
+                                                onEditPlay={handleEditPlay}
                                             />
                                         </Card>
-                                    )
-                                ) : (
-                                    <>
-                                        <DefenseCard
-                                            teamName={team.name}
-                                            dueUpBatters={dueUpBatters}
-                                        />
-                                        {isScorekeeper && (
-                                            <FieldingControls
-                                                onOut={handleOpponentOut}
-                                                onRun={handleOpponentRun}
-                                                onSkip={advanceHalfInning}
-                                            />
-                                        )}
-                                    </>
-                                ))}
-                        </Stack>
-                    </Grid.Col>
+                                    </Stack>
+                                </Tabs.Panel>
 
-                    {/* COLUMN 3: Tabs */}
-                    <Grid.Col span={{ base: 12, md: 4 }}>
-                        <TabsWrapper
-                            value={activeTab}
-                            onChange={(val) => handleTabChange(val)}
-                            mt={0}
-                            size="sm"
-                        >
-                            <Tabs.Tab value="plays">Plays</Tabs.Tab>
-                            <Tabs.Tab value="boxscore">Box Score</Tabs.Tab>
-                            <Tabs.Tab value="spray">Spray Chart</Tabs.Tab>
-                            {gameFinal && (
-                                <Tabs.Tab value="achievements">
-                                    Achievements
-                                </Tabs.Tab>
-                            )}
-
-                            <Tabs.Panel value="plays" pt="md">
-                                <Stack gap="md">
-                                    <Card radius="md" p="xs">
-                                        <PlayHistoryList
-                                            logs={logs}
-                                            playerChart={playerChart}
-                                            isScorekeeper={isScorekeeper}
-                                            onEditPlay={handleEditPlay}
-                                        />
-                                    </Card>
-                                </Stack>
-                            </Tabs.Panel>
-
-                            <Tabs.Panel value="boxscore" pt="md">
-                                <BoxScore
-                                    logs={logs}
-                                    playerChart={playerChart}
-                                    currentBatter={currentBatter}
-                                    gameFinal={gameFinal}
-                                />
-                            </Tabs.Panel>
-
-                            <Tabs.Panel value="spray" pt="md">
-                                <ContactSprayChart
-                                    hits={logs}
-                                    showBattingSide={false}
-                                    batters={batters}
-                                />
-                            </Tabs.Panel>
-
-                            {gameFinal && (
-                                <Tabs.Panel value="achievements" pt="md">
-                                    <AchievementsList
-                                        achievements={achievements}
-                                        players={players}
-                                        user={user}
+                                <Tabs.Panel value="boxscore" pt="md">
+                                    <BoxScore
+                                        logs={logs}
+                                        playerChart={playerChart}
+                                        currentBatter={currentBatter}
+                                        gameFinal={gameFinal}
                                     />
                                 </Tabs.Panel>
-                            )}
-                        </TabsWrapper>
-                    </Grid.Col>
-                </Grid>
-            </Box>
+
+                                <Tabs.Panel value="spray" pt="md">
+                                    <ContactSprayChart
+                                        hits={logs}
+                                        showBattingSide={false}
+                                        batters={batters}
+                                    />
+                                </Tabs.Panel>
+
+                                {gameFinal && (
+                                    <Tabs.Panel value="achievements" pt="md">
+                                        <AchievementsList
+                                            achievements={achievements}
+                                            players={players}
+                                            user={user}
+                                        />
+                                    </Tabs.Panel>
+                                )}
+                            </TabsWrapper>
+                        </Grid.Col>
+                    </Grid>
+                </Box>
+            )}
 
             <DesktopPlayActionDrawer
                 opened={drawerOpened}

--- a/app/routes/gameday/components/MobileGamedayContainer.jsx
+++ b/app/routes/gameday/components/MobileGamedayContainer.jsx
@@ -1,6 +1,8 @@
 import { useState, useMemo } from "react";
+import { Link } from "react-router";
 import {
     Box,
+    Button,
     Card,
     Group,
     LoadingOverlay,
@@ -97,19 +99,6 @@ export default function MobileGamedayContainer({
         return idx > 0 ? logs[idx - 1] : null;
     }, [editLog, logs]);
 
-    if (playerChart.length === 0) {
-        return (
-            <Card p="xl" radius="lg" ta="center">
-                <Text fw={700} mb="xs">
-                    Lineup Required
-                </Text>
-                <Text size="sm" c="dimmed">
-                    You must create a lineup before scoring.
-                </Text>
-            </Card>
-        );
-    }
-
     const handleEditPlay = (log) => {
         setEditLog(log);
         openEditDrawer();
@@ -155,150 +144,190 @@ export default function MobileGamedayContainer({
                 </Group>
             </Group>
 
-            <ScoreboardHeader
-                score={score}
-                opponentScore={opponentScore}
-                inning={inning}
-                halfInning={halfInning}
-                outs={outs}
-                teamName={team.name}
-                opponentName={game.opponent}
-                gameFinal={gameFinal}
-                realtimeStatus={realtimeStatus}
-                isOurBatting={isOurBatting}
-                runners={runners}
-            />
-
-            <Box pos="relative">
-                <LoadingOverlay
-                    visible={isSyncing}
-                    overlayProps={{ radius: "lg", blur: 1, opacity: 0.1 }}
-                    loaderProps={{ color: "blue", type: "dots" }}
-                    zIndex={100}
-                />
-                <TabsWrapper
-                    value={activeTab}
-                    onChange={handleTabChange}
-                    mt={0}
-                >
-                    {!gameFinal && <Tabs.Tab value="live">Live</Tabs.Tab>}
-                    <Tabs.Tab value="plays">Plays</Tabs.Tab>
-                    <Tabs.Tab value="boxscore">Box Score</Tabs.Tab>
-                    <Tabs.Tab value="spray">Spray</Tabs.Tab>
-                    {gameFinal && (
-                        <Tabs.Tab value="achievements">Achievements</Tabs.Tab>
+            {playerChart.length === 0 ? (
+                <Card p="xl" radius="lg" ta="center">
+                    <Text fw={700} mb="xs">
+                        Lineup Required
+                    </Text>
+                    <Text size="sm" c="dimmed" mb="md">
+                        You must create a lineup before scoring.
+                    </Text>
+                    {isScorekeeper && (
+                        <Button
+                            component={Link}
+                            to={`/events/${game.$id}/lineup`}
+                            variant="filled"
+                            color="lime"
+                            mt="xs"
+                        >
+                            Create Lineup
+                        </Button>
                     )}
+                </Card>
+            ) : (
+                <>
+                    <ScoreboardHeader
+                        score={score}
+                        opponentScore={opponentScore}
+                        inning={inning}
+                        halfInning={halfInning}
+                        outs={outs}
+                        teamName={team.name}
+                        opponentName={game.opponent}
+                        gameFinal={gameFinal}
+                        realtimeStatus={realtimeStatus}
+                        isOurBatting={isOurBatting}
+                        runners={runners}
+                    />
 
-                    <Tabs.Panel value="live" pt="md">
-                        <Stack gap="md">
+                    <Box pos="relative">
+                        <LoadingOverlay
+                            visible={isSyncing}
+                            overlayProps={{
+                                radius: "lg",
+                                blur: 1,
+                                opacity: 0.1,
+                            }}
+                            loaderProps={{ color: "blue", type: "dots" }}
+                            zIndex={100}
+                        />
+                        <TabsWrapper
+                            value={activeTab}
+                            onChange={handleTabChange}
+                            mt={0}
+                        >
                             {!gameFinal && (
-                                <>
-                                    {isOurBatting ? (
-                                        <>
-                                            <CurrentBatterCard
-                                                currentBatter={currentBatter}
-                                                logs={logs}
-                                            />
-                                            <UpNextCard
-                                                upcomingBatters={
-                                                    upcomingBatters
-                                                }
-                                            />
-                                        </>
-                                    ) : (
-                                        <DefenseCard
-                                            teamName={team.name}
-                                            dueUpBatters={dueUpBatters}
-                                        />
-                                    )}
-                                </>
+                                <Tabs.Tab value="live">Live</Tabs.Tab>
+                            )}
+                            <Tabs.Tab value="plays">Plays</Tabs.Tab>
+                            <Tabs.Tab value="boxscore">Box Score</Tabs.Tab>
+                            <Tabs.Tab value="spray">Spray</Tabs.Tab>
+                            {gameFinal && (
+                                <Tabs.Tab value="achievements">
+                                    Achievements
+                                </Tabs.Tab>
                             )}
 
-                            {isScorekeeper && !gameFinal && (
-                                <Stack flex={1} gap="md">
-                                    {isOurBatting ? (
-                                        <ActionPad
-                                            onAction={initiateAction}
-                                            runners={runners}
-                                            outs={outs}
-                                        />
-                                    ) : (
-                                        <FieldingControls
-                                            onOut={handleOpponentOut}
-                                            onRun={handleOpponentRun}
-                                            onSkip={advanceHalfInning}
-                                        />
+                            <Tabs.Panel value="live" pt="md">
+                                <Stack gap="md">
+                                    {!gameFinal && (
+                                        <>
+                                            {isOurBatting ? (
+                                                <>
+                                                    <CurrentBatterCard
+                                                        currentBatter={
+                                                            currentBatter
+                                                        }
+                                                        logs={logs}
+                                                    />
+                                                    <UpNextCard
+                                                        upcomingBatters={
+                                                            upcomingBatters
+                                                        }
+                                                    />
+                                                </>
+                                            ) : (
+                                                <DefenseCard
+                                                    teamName={team.name}
+                                                    dueUpBatters={dueUpBatters}
+                                                />
+                                            )}
+                                        </>
+                                    )}
+
+                                    {isScorekeeper && !gameFinal && (
+                                        <Stack flex={1} gap="md">
+                                            {isOurBatting ? (
+                                                <ActionPad
+                                                    onAction={initiateAction}
+                                                    runners={runners}
+                                                    outs={outs}
+                                                />
+                                            ) : (
+                                                <FieldingControls
+                                                    onOut={handleOpponentOut}
+                                                    onRun={handleOpponentRun}
+                                                    onSkip={advanceHalfInning}
+                                                />
+                                            )}
+                                        </Stack>
+                                    )}
+
+                                    {logs.length > 0 && isOurBatting && (
+                                        <Box>
+                                            <LastPlayCard
+                                                lastLog={logs[logs.length - 1]}
+                                                onUndo={
+                                                    isScorekeeper
+                                                        ? undoLast
+                                                        : null
+                                                }
+                                                isSubmitting={isSubmitting}
+                                                playerChart={playerChart}
+                                            />
+                                        </Box>
                                     )}
                                 </Stack>
-                            )}
+                            </Tabs.Panel>
 
-                            {logs.length > 0 && isOurBatting && (
-                                <Box>
-                                    <LastPlayCard
-                                        lastLog={logs[logs.length - 1]}
-                                        onUndo={isScorekeeper ? undoLast : null}
-                                        isSubmitting={isSubmitting}
-                                        playerChart={playerChart}
-                                    />
-                                </Box>
-                            )}
-                        </Stack>
-                    </Tabs.Panel>
-
-                    <Tabs.Panel value="plays" pt="md">
-                        <Stack gap="md">
-                            {!gameFinal && (
-                                <>
-                                    {isOurBatting ? (
-                                        <CurrentBatterCard
-                                            currentBatter={currentBatter}
-                                            logs={logs}
-                                        />
-                                    ) : (
-                                        <DefenseCard
-                                            teamName={team.name}
-                                            dueUpBatters={dueUpBatters}
-                                        />
+                            <Tabs.Panel value="plays" pt="md">
+                                <Stack gap="md">
+                                    {!gameFinal && (
+                                        <>
+                                            {isOurBatting ? (
+                                                <CurrentBatterCard
+                                                    currentBatter={
+                                                        currentBatter
+                                                    }
+                                                    logs={logs}
+                                                />
+                                            ) : (
+                                                <DefenseCard
+                                                    teamName={team.name}
+                                                    dueUpBatters={dueUpBatters}
+                                                />
+                                            )}
+                                        </>
                                     )}
-                                </>
+                                    <PlayHistoryList
+                                        logs={logs}
+                                        playerChart={playerChart}
+                                        isScorekeeper={isScorekeeper}
+                                        onEditPlay={handleEditPlay}
+                                    />
+                                </Stack>
+                            </Tabs.Panel>
+
+                            <Tabs.Panel value="boxscore" pt="md">
+                                <BoxScore
+                                    logs={logs}
+                                    playerChart={playerChart}
+                                    currentBatter={currentBatter}
+                                    gameFinal={gameFinal}
+                                />
+                            </Tabs.Panel>
+
+                            <Tabs.Panel value="spray" pt="md">
+                                <ContactSprayChart
+                                    hits={logs}
+                                    showBattingSide={false}
+                                    batters={batters}
+                                />
+                            </Tabs.Panel>
+
+                            {gameFinal && (
+                                <Tabs.Panel value="achievements" pt="md">
+                                    <AchievementsList
+                                        achievements={achievements}
+                                        players={players}
+                                        user={user}
+                                    />
+                                </Tabs.Panel>
                             )}
-                            <PlayHistoryList
-                                logs={logs}
-                                playerChart={playerChart}
-                                isScorekeeper={isScorekeeper}
-                                onEditPlay={handleEditPlay}
-                            />
-                        </Stack>
-                    </Tabs.Panel>
-
-                    <Tabs.Panel value="boxscore" pt="md">
-                        <BoxScore
-                            logs={logs}
-                            playerChart={playerChart}
-                            currentBatter={currentBatter}
-                            gameFinal={gameFinal}
-                        />
-                    </Tabs.Panel>
-
-                    <Tabs.Panel value="spray" pt="md">
-                        <ContactSprayChart
-                            hits={logs}
-                            showBattingSide={false}
-                            batters={batters}
-                        />
-                    </Tabs.Panel>
-
-                    {gameFinal && (
-                        <Tabs.Panel value="achievements" pt="md">
-                            <AchievementsList
-                                achievements={achievements}
-                                players={players}
-                                user={user}
-                            />
-                        </Tabs.Panel>
-                    )}
-                </TabsWrapper>
-            </Box>
+                        </TabsWrapper>
+                    </Box>
+                </>
+            )}
 
             <MobilePlayActionDrawer
                 opened={drawerOpened}

--- a/app/routes/gameday/components/tests/DesktopGamedayContainer.test.jsx
+++ b/app/routes/gameday/components/tests/DesktopGamedayContainer.test.jsx
@@ -26,6 +26,11 @@ jest.mock("react-router", () => ({
     useLocation: () => ({ hash: "", pathname: "/gameday", search: "" }),
     useNavigate: () => jest.fn(),
     useParams: () => ({ eventId: "game123" }),
+    Link: ({ to, children, ...props }) => (
+        <a href={to} {...props}>
+            {children}
+        </a>
+    ),
 }));
 
 jest.mock("@/hooks/useGameUpdates");
@@ -245,6 +250,65 @@ describe("DesktopGamedayContainer", () => {
 
             // Verify drawer content (title is in EditPlayDrawer)
             expect(await screen.findByText("Edit Play")).toBeInTheDocument();
+        });
+    });
+
+    describe("Empty lineup UI features", () => {
+        it("renders page header and Lineup Required card, and shows Create Lineup CTA for scorekeepers", () => {
+            render(
+                <DesktopGamedayContainer
+                    game={mockGame}
+                    playerChart={[]}
+                    team={mockTeam}
+                    initialLogs={[]}
+                    isScorekeeper={true}
+                />,
+            );
+
+            // Verify header remains visible
+            expect(screen.getByText("Scoring & Stats")).toBeInTheDocument();
+            expect(
+                screen.getByRole("button", { name: "Back" }),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("button", { name: /share page/i }),
+            ).toBeInTheDocument();
+
+            // Verify Lineup Required notice and Create Lineup button
+            expect(screen.getByText("Lineup Required")).toBeInTheDocument();
+            expect(
+                screen.getByText("You must create a lineup before scoring."),
+            ).toBeInTheDocument();
+
+            const createLineupBtn = screen.getByRole("link", {
+                name: /create lineup/i,
+            });
+            expect(createLineupBtn).toBeInTheDocument();
+            expect(createLineupBtn).toHaveAttribute(
+                "href",
+                "/events/game123/lineup",
+            );
+        });
+
+        it("renders page header and Lineup Required card, but hides Create Lineup CTA for non-scorekeepers", () => {
+            render(
+                <DesktopGamedayContainer
+                    game={mockGame}
+                    playerChart={[]}
+                    team={mockTeam}
+                    initialLogs={[]}
+                    isScorekeeper={false}
+                />,
+            );
+
+            // Verify header remains visible
+            expect(screen.getByText("Scoring & Stats")).toBeInTheDocument();
+
+            // Verify Lineup Required notice
+            expect(screen.getByText("Lineup Required")).toBeInTheDocument();
+            expect(
+                screen.queryByRole("link", { name: /create lineup/i }),
+            ).not.toBeInTheDocument();
         });
     });
 });

--- a/app/routes/gameday/components/tests/MobileGamedayContainer.test.jsx
+++ b/app/routes/gameday/components/tests/MobileGamedayContainer.test.jsx
@@ -26,6 +26,11 @@ jest.mock("react-router", () => ({
     useLocation: () => ({ hash: "", pathname: "/gameday", search: "" }),
     useNavigate: () => jest.fn(),
     useParams: () => ({ eventId: "game123" }),
+    Link: ({ to, children, ...props }) => (
+        <a href={to} {...props}>
+            {children}
+        </a>
+    ),
 }));
 
 jest.mock("@/hooks/useGameUpdates");
@@ -253,6 +258,65 @@ describe("MobileGamedayContainer", () => {
 
             // Verify drawer content (title is in EditPlayDrawer)
             expect(await screen.findByText("Edit Play")).toBeInTheDocument();
+        });
+    });
+
+    describe("Empty lineup UI features", () => {
+        it("renders page header and Lineup Required card, and shows Create Lineup CTA for scorekeepers", () => {
+            render(
+                <MobileGamedayContainer
+                    game={mockGame}
+                    playerChart={[]}
+                    team={mockTeam}
+                    initialLogs={[]}
+                    isScorekeeper={true}
+                />,
+            );
+
+            // Verify header remains visible
+            expect(screen.getByText("Scoring & Stats")).toBeInTheDocument();
+            expect(
+                screen.getByRole("button", { name: "Back" }),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("button", { name: /share page/i }),
+            ).toBeInTheDocument();
+
+            // Verify Lineup Required notice and Create Lineup button
+            expect(screen.getByText("Lineup Required")).toBeInTheDocument();
+            expect(
+                screen.getByText("You must create a lineup before scoring."),
+            ).toBeInTheDocument();
+
+            const createLineupBtn = screen.getByRole("link", {
+                name: /create lineup/i,
+            });
+            expect(createLineupBtn).toBeInTheDocument();
+            expect(createLineupBtn).toHaveAttribute(
+                "href",
+                "/events/game123/lineup",
+            );
+        });
+
+        it("renders page header and Lineup Required card, but hides Create Lineup CTA for non-scorekeepers", () => {
+            render(
+                <MobileGamedayContainer
+                    game={mockGame}
+                    playerChart={[]}
+                    team={mockTeam}
+                    initialLogs={[]}
+                    isScorekeeper={false}
+                />,
+            );
+
+            // Verify header remains visible
+            expect(screen.getByText("Scoring & Stats")).toBeInTheDocument();
+
+            // Verify Lineup Required notice
+            expect(screen.getByText("Lineup Required")).toBeInTheDocument();
+            expect(
+                screen.queryByRole("link", { name: /create lineup/i }),
+            ).not.toBeInTheDocument();
         });
     });
 });

--- a/app/routes/user/components/MobileProfileView.jsx
+++ b/app/routes/user/components/MobileProfileView.jsx
@@ -25,18 +25,10 @@ export default function MobileProfileView({
 
     return (
         <TabsWrapper value={activeTab} onChange={handleTabChange}>
-            <Tabs.Tab value="player">
-                Details
-            </Tabs.Tab>
-            <Tabs.Tab value="stats">
-                Stats
-            </Tabs.Tab>
-            <Tabs.Tab value="awards">
-                Awards
-            </Tabs.Tab>
-            <Tabs.Tab value="achievements">
-                Achievements
-            </Tabs.Tab>
+            <Tabs.Tab value="player">Details</Tabs.Tab>
+            <Tabs.Tab value="stats">Stats</Tabs.Tab>
+            <Tabs.Tab value="awards">Awards</Tabs.Tab>
+            <Tabs.Tab value="achievements">Achievements</Tabs.Tab>
 
             <Tabs.Panel value="player">
                 <PersonalDetails player={player} user={loggedInUser} />
@@ -71,7 +63,7 @@ export default function MobileProfileView({
             </Tabs.Panel>
 
             <Tabs.Panel value="achievements" mt="md">
-                <PlayerAchievements 
+                <PlayerAchievements
                     achievementsPromise={achievementsPromise}
                     playerName={player.firstName}
                     isMe={loggedInUser?.$id === player?.$id}

--- a/app/routes/user/components/tests/PlayerAchievements.test.jsx
+++ b/app/routes/user/components/tests/PlayerAchievements.test.jsx
@@ -29,9 +29,7 @@ const renderComponent = (promise) => {
     const routes = [
         {
             path: "/",
-            element: (
-                <PlayerAchievements achievementsPromise={promise} />
-            ),
+            element: <PlayerAchievements achievementsPromise={promise} />,
         },
     ];
 
@@ -44,8 +42,12 @@ describe("PlayerAchievements", () => {
         const promise = Promise.resolve([]);
         renderComponent(promise);
 
-        expect(await screen.findByText(/No Achievements Yet/i)).toBeInTheDocument();
-        expect(screen.getByText(/Keep playing to unlock achievements/i)).toBeInTheDocument();
+        expect(
+            await screen.findByText(/No Achievements Yet/i),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/Keep playing to unlock achievements/i),
+        ).toBeInTheDocument();
     });
 
     it("renders achievement dashboard and list correctly", async () => {
@@ -53,8 +55,12 @@ describe("PlayerAchievements", () => {
         renderComponent(promise);
 
         // Dashboard Stats
-        expect(await screen.findByTestId("rarity-filter-all")).toBeInTheDocument();
-        expect(screen.getByTestId("rarity-filter-legendary")).toBeInTheDocument();
+        expect(
+            await screen.findByTestId("rarity-filter-all"),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByTestId("rarity-filter-legendary"),
+        ).toBeInTheDocument();
         expect(screen.getByTestId("rarity-filter-rare")).toBeInTheDocument();
 
         // Initial list

--- a/app/routes/user/profile.jsx
+++ b/app/routes/user/profile.jsx
@@ -54,7 +54,13 @@ export async function loader({ params, request }) {
     const url = new URL(request.url);
     const hash = url.hash.replace(/^#/, "") || null;
 
-    const validTabs = ["player", "stats", "awards", "attendance", "achievements"];
+    const validTabs = [
+        "player",
+        "stats",
+        "awards",
+        "attendance",
+        "achievements",
+    ];
     const defaultTab = validTabs.includes(hash) ? hash : "player";
 
     const sessionClient = await createSessionClient(request);
@@ -67,7 +73,10 @@ export async function loader({ params, request }) {
             client: sessionClient,
         }),
         statsPromise: getStatsByUserId({ userId, client: sessionClient }),
-        achievementsPromise: getAchievementsByUserId({ userId, client: sessionClient }),
+        achievementsPromise: getAchievementsByUserId({
+            userId,
+            client: sessionClient,
+        }),
         defaultTab,
     };
 }
@@ -98,7 +107,13 @@ export default function UserProfile({ loaderData }) {
 
     useResponseNotification(actionData);
 
-    const validTabs = ["player", "stats", "awards", "attendance", "achievements"];
+    const validTabs = [
+        "player",
+        "stats",
+        "awards",
+        "attendance",
+        "achievements",
+    ];
     const [tab, setTab] = useState(defaultTab);
 
     // Keep tab state in sync when location.hash changes (back/forward navigation)

--- a/app/utils/tests/databases.test.js
+++ b/app/utils/tests/databases.test.js
@@ -1,4 +1,13 @@
-let createDocument, listDocuments, readDocument, updateDocument, deleteDocument, createTransaction, createOperations, commitTransaction, rollbackTransaction, collections;
+let createDocument,
+    listDocuments,
+    readDocument,
+    updateDocument,
+    deleteDocument,
+    createTransaction,
+    createOperations,
+    commitTransaction,
+    rollbackTransaction,
+    collections;
 
 const mockTablesDB = {
     createRow: jest.fn(),
@@ -26,7 +35,8 @@ describe("databases utility", () => {
 
         // Mock environment variables
         process.env.APPWRITE_ACHIEVEMENTS_COLLECTION_ID = "achievements-id";
-        process.env.APPWRITE_USER_ACHIEVEMENTS_COLLECTION_ID = "user-achievements-id";
+        process.env.APPWRITE_USER_ACHIEVEMENTS_COLLECTION_ID =
+            "user-achievements-id";
         process.env.APPWRITE_DATABASE_ID = "db-id";
         process.env.APPWRITE_USERS_COLLECTION_ID = "users-id";
 


### PR DESCRIPTION
[![Render.com PR #187 ENV](https://img.shields.io/badge/Render.com%20PR%20%23187%20ENV-blue)](https://softball-manager-react-router-pr-187.onrender.com/)

### Overview
This pull request ensures that the `/gameday` scoring and statistics page always renders the top header row (back button, title, share button, and menu), regardless of whether a lineup has been created for the game. For games without a lineup, it adds a centered call-to-action (CTA) card to let scorekeepers (`isScorekeeper === true`) navigate directly to the lineup creation page.

### Key Changes
1. **Unconditional Header**: Modified both `DesktopGamedayContainer` and `MobileGamedayContainer` to render the header group at the top level of the render tree.
2. **Lineup Required CTA**: Render a clean Mantine `Card` when `playerChart.length === 0` explaining that a lineup is required, and conditionally display a neon lime `"Create Lineup"` button for scorekeepers, which points back to `/events/:eventId/lineup`.
3. **Unit Testing**: Added dedicated unit test suites in `DesktopGamedayContainer.test.jsx` and `MobileGamedayContainer.test.jsx` checking correct rendering for both scorekeepers and non-scorekeepers.
4. **Code Quality**: Formatted and linted all files according to project guidelines. All 280 test suites pass successfully on push.
