### PR TITLE
feat(gameday): support scoring multiple opponent runs at once on defense screen

### DIFF
--- a/app/routes/gameday/components/FieldingControls.jsx
+++ b/app/routes/gameday/components/FieldingControls.jsx
@@ -1,6 +1,31 @@
-import { Stack, Text, Group, Button } from "@mantine/core";
+import { useState } from "react";
+import { Stack, Text, Group, Button, ActionIcon } from "@mantine/core";
+import { IconChevronUp, IconChevronDown } from "@tabler/icons-react";
 
+/**
+ * FieldingControls component renders the action controls when our team is on defense.
+ * It provides buttons to record an out, score runs for the opponent, or skip to batting.
+ * Includes a run counter to score multiple opponent runs with a single click.
+ *
+ * @component
+ * @param {Object} props
+ * @param {Function} props.onOut - Callback triggered when recording an out.
+ * @param {Function} props.onRun - Callback triggered when scoring runs. Receives the number of runs scored.
+ * @param {Function} props.onSkip - Callback triggered to advance/skip to batting.
+ * @returns {JSX.Element} The rendered FieldingControls component.
+ */
 export default function FieldingControls({ onOut, onRun, onSkip }) {
+    const [runsToScore, setRunsToScore] = useState(1);
+
+    /**
+     * Handles run scoring action, submits the current run count,
+     * and resets the local run counter back to 1.
+     */
+    const handleRunClick = () => {
+        onRun(runsToScore);
+        setRunsToScore(1);
+    };
+
     return (
         <Stack gap="md">
             <Text size="sm" fw={700} c="dimmed">
@@ -12,11 +37,42 @@ export default function FieldingControls({ onOut, onRun, onSkip }) {
                         OUT
                     </Text>
                 </Button>
-                <Button h={80} color="lime.4" radius="md" onClick={onRun}>
-                    <Text size="md" fw={900}>
-                        RUN
-                    </Text>
-                </Button>
+                <Group gap="xs" align="center" wrap="nowrap">
+                    <Button
+                        h={80}
+                        color="lime.4"
+                        radius="md"
+                        style={{ flex: 1 }}
+                        onClick={handleRunClick}
+                    >
+                        <Text size="md" fw={900}>
+                            {runsToScore === 1 ? "RUN" : `${runsToScore} RUNS`}
+                        </Text>
+                    </Button>
+                    <Stack gap={4} justify="center" h={80}>
+                        <ActionIcon
+                            size={38}
+                            variant="filled"
+                            color="lime.4"
+                            onClick={() => setRunsToScore((prev) => prev + 1)}
+                            aria-label="Increase runs"
+                        >
+                            <IconChevronUp size={20} />
+                        </ActionIcon>
+                        <ActionIcon
+                            size={38}
+                            variant="filled"
+                            color="lime.4"
+                            disabled={runsToScore <= 1}
+                            onClick={() =>
+                                setRunsToScore((prev) => Math.max(1, prev - 1))
+                            }
+                            aria-label="Decrease runs"
+                        >
+                            <IconChevronDown size={20} />
+                        </ActionIcon>
+                    </Stack>
+                </Group>
             </Group>
             <Button variant="filled" color="blue" radius="md" onClick={onSkip}>
                 Skip to Batting

--- a/app/routes/gameday/components/tests/FieldingControls.test.jsx
+++ b/app/routes/gameday/components/tests/FieldingControls.test.jsx
@@ -6,6 +6,10 @@ describe("FieldingControls", () => {
     const mockOnRun = jest.fn();
     const mockOnSkip = jest.fn();
 
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it("renders all buttons", () => {
         render(
             <FieldingControls
@@ -19,6 +23,12 @@ describe("FieldingControls", () => {
         expect(screen.getByRole("button", { name: "RUN" })).toBeInTheDocument();
         expect(
             screen.getByRole("button", { name: "Skip to Batting" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Increase runs" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Decrease runs" }),
         ).toBeInTheDocument();
     });
 
@@ -34,7 +44,7 @@ describe("FieldingControls", () => {
         expect(mockOnOut).toHaveBeenCalled();
     });
 
-    it("calls onRun handler when RUN button is clicked", () => {
+    it("calls onRun handler when RUN button is clicked with default 1 run", () => {
         render(
             <FieldingControls
                 onOut={mockOnOut}
@@ -43,7 +53,92 @@ describe("FieldingControls", () => {
             />,
         );
         fireEvent.click(screen.getByRole("button", { name: "RUN" }));
-        expect(mockOnRun).toHaveBeenCalled();
+        expect(mockOnRun).toHaveBeenCalledWith(1);
+    });
+
+    it("increments runs when Increase runs button is clicked", () => {
+        render(
+            <FieldingControls
+                onOut={mockOnOut}
+                onRun={mockOnRun}
+                onSkip={mockOnSkip}
+            />,
+        );
+        const increaseButton = screen.getByRole("button", {
+            name: "Increase runs",
+        });
+
+        fireEvent.click(increaseButton);
+        expect(
+            screen.getByRole("button", { name: "2 RUNS" }),
+        ).toBeInTheDocument();
+
+        fireEvent.click(increaseButton);
+        expect(
+            screen.getByRole("button", { name: "3 RUNS" }),
+        ).toBeInTheDocument();
+    });
+
+    it("decrements runs when Decrease runs button is clicked but not below 1", () => {
+        render(
+            <FieldingControls
+                onOut={mockOnOut}
+                onRun={mockOnRun}
+                onSkip={mockOnSkip}
+            />,
+        );
+        const increaseButton = screen.getByRole("button", {
+            name: "Increase runs",
+        });
+        const decreaseButton = screen.getByRole("button", {
+            name: "Decrease runs",
+        });
+
+        // Starts disabled at 1
+        expect(decreaseButton).toBeDisabled();
+
+        // Increment to 3
+        fireEvent.click(increaseButton);
+        fireEvent.click(increaseButton);
+        expect(decreaseButton).not.toBeDisabled();
+        expect(
+            screen.getByRole("button", { name: "3 RUNS" }),
+        ).toBeInTheDocument();
+
+        // Decrement to 2
+        fireEvent.click(decreaseButton);
+        expect(
+            screen.getByRole("button", { name: "2 RUNS" }),
+        ).toBeInTheDocument();
+
+        // Decrement to 1
+        fireEvent.click(decreaseButton);
+        expect(screen.getByRole("button", { name: "RUN" })).toBeInTheDocument();
+        expect(decreaseButton).toBeDisabled();
+    });
+
+    it("calls onRun with correct runs count and resets to 1", () => {
+        render(
+            <FieldingControls
+                onOut={mockOnOut}
+                onRun={mockOnRun}
+                onSkip={mockOnSkip}
+            />,
+        );
+        const increaseButton = screen.getByRole("button", {
+            name: "Increase runs",
+        });
+
+        fireEvent.click(increaseButton);
+        fireEvent.click(increaseButton); // Now 3 runs
+
+        const scoreButton = screen.getByRole("button", { name: "3 RUNS" });
+        fireEvent.click(scoreButton);
+
+        expect(mockOnRun).toHaveBeenCalledWith(3);
+
+        // Counter should reset to 1 (rendering "RUN")
+        expect(screen.getByRole("button", { name: "RUN" })).toBeInTheDocument();
     });
 
     it("calls onSkip handler when Skip button is clicked", () => {

--- a/app/routes/gameday/hooks/tests/useGamedayActions.test.jsx
+++ b/app/routes/gameday/hooks/tests/useGamedayActions.test.jsx
@@ -68,6 +68,25 @@ describe("useGamedayActions", () => {
         );
     });
 
+    it("handles multiple opponent runs correctly", () => {
+        const { result } = renderHook(() => useGamedayActions(defaultProps));
+
+        act(() => {
+            result.current.handleOpponentRun(5);
+        });
+
+        expect(defaultProps.setOpponentScore).toHaveBeenCalledWith(
+            expect.any(Function),
+        );
+        const updater = defaultProps.setOpponentScore.mock.calls[0][0];
+        expect(updater(0)).toBe(5);
+
+        expect(mockSubmit).toHaveBeenCalledWith(
+            { _action: "update-game-score", opponentScore: 5 },
+            { method: "post" },
+        );
+    });
+
     it("handles opponent out with inning advance", () => {
         const propsWith2Outs = { ...defaultProps, outs: 2 };
         const { result } = renderHook(() => useGamedayActions(propsWith2Outs));

--- a/app/routes/gameday/hooks/useGamedayActions.js
+++ b/app/routes/gameday/hooks/useGamedayActions.js
@@ -61,14 +61,22 @@ export function useGamedayActions({
         }
     }, [halfInning, setHalfInning, setInning, setOuts, setRunners]);
 
-    const handleOpponentRun = useCallback(() => {
-        setOpponentScore((prev) => prev + 1);
+    const handleOpponentRun = useCallback(
+        (runs = 1) => {
+            const increment =
+                typeof runs === "number" && !isNaN(runs) ? runs : 1;
+            setOpponentScore((prev) => prev + increment);
 
-        fetcher.submit(
-            { _action: "update-game-score", opponentScore: opponentScore + 1 },
-            { method: "post" },
-        );
-    }, [fetcher, opponentScore, setOpponentScore]);
+            fetcher.submit(
+                {
+                    _action: "update-game-score",
+                    opponentScore: opponentScore + increment,
+                },
+                { method: "post" },
+            );
+        },
+        [fetcher, opponentScore, setOpponentScore],
+    );
 
     const handleOpponentOut = useCallback(() => {
         let isInningOver = false;


### PR DESCRIPTION
[![Render.com PR #191 ENV](https://img.shields.io/badge/Render.com%20PR%20%23191%20ENV-blue)](https://softball-manager-react-router-pr-191.onrender.com/)

Implement run count up/down buttons on the scoring defense screen to score multiple opponent runs with a single click and network request. Resolves UI button text truncation by dynamically labeling as 'RUN' or 'X RUNS'.
