### PR TITLE
feat(scoring): combine FLY/POP scoring buttons with dynamic resolution

### DIFF
--- a/app/constants/scoring.js
+++ b/app/constants/scoring.js
@@ -10,6 +10,7 @@ export const UI_KEYS = {
     FLY_OUT: "Fly Out",
     LINE_OUT: "Line Out",
     POP_OUT: "Pop Out",
+    FLY_POP: "Fly/Pop Out",
     ERROR: "E",
     FIELDERS_CHOICE: "FC",
     SACRIFICE_FLY: "SF",

--- a/app/routes/gameday/components/ActionPad.jsx
+++ b/app/routes/gameday/components/ActionPad.jsx
@@ -15,9 +15,8 @@ const OUT_COLOR = "red";
 const outs = [
     { label: "K", color: OUT_COLOR, value: UI_KEYS.STRIKEOUT },
     { label: "GRD", color: OUT_COLOR, value: UI_KEYS.GROUND_OUT },
-    { label: "FLY", color: OUT_COLOR, value: UI_KEYS.FLY_OUT },
+    { label: "FLY/POP", color: OUT_COLOR, value: UI_KEYS.FLY_POP },
     { label: "LINE", color: OUT_COLOR, value: UI_KEYS.LINE_OUT },
-    { label: "POP", color: OUT_COLOR, value: UI_KEYS.POP_OUT },
 ];
 
 export default function ActionPad({ onAction, runners, outs: currentOuts }) {
@@ -54,6 +53,8 @@ export default function ActionPad({ onAction, runners, outs: currentOuts }) {
                             variant={btn.variant || "filled"}
                             radius="md"
                             onClick={() => onAction(btn.value)}
+                            px={btn.label.length > 4 ? 4 : undefined}
+                            fz={btn.label.length > 4 ? "xs" : "sm"}
                         >
                             {btn.label}
                         </Button>
@@ -74,6 +75,8 @@ export default function ActionPad({ onAction, runners, outs: currentOuts }) {
                             radius="md"
                             onClick={() => onAction(btn.value)}
                             disabled={btn.disabled}
+                            px={btn.label.length > 4 ? 4 : undefined}
+                            fz={btn.label.length > 4 ? "xs" : "sm"}
                         >
                             {btn.label}
                         </Button>

--- a/app/routes/gameday/components/DesktopGamedayLoadingSkeleton.jsx
+++ b/app/routes/gameday/components/DesktopGamedayLoadingSkeleton.jsx
@@ -179,9 +179,6 @@ export default function DesktopGamedayLoadingSkeleton() {
                                             <Skeleton height={40} radius="md" />
                                             <Skeleton height={40} radius="md" />
                                         </Group>
-                                        <Box w="50%" pr="xs">
-                                            <Skeleton height={40} radius="md" />
-                                        </Box>
                                     </Stack>
                                 </Group>
                             </Card>

--- a/app/routes/gameday/components/DesktopPlayActionDrawer.jsx
+++ b/app/routes/gameday/components/DesktopPlayActionDrawer.jsx
@@ -22,6 +22,7 @@ import FieldHighlight from "./FieldHighlight";
 
 import { useRunnerProjection } from "../hooks/useRunnerProjection";
 import { getDrawerTitle, getActionColor } from "../utils/drawerUtils";
+import { ORIGIN_X, ORIGIN_Y, DEPTH_THRESHOLD } from "@/constants/fieldMapping";
 import {
     getFieldZone,
     getClampedCoordinates,
@@ -33,7 +34,7 @@ export default function DesktopPlayActionDrawer({
     opened,
     onClose,
     onSelect,
-    actionType,
+    actionType: initialActionType,
     runners,
     playerChart,
     currentBatter,
@@ -50,6 +51,20 @@ export default function DesktopPlayActionDrawer({
     const [isLocked, setIsLocked] = useState(false);
     const [showConfirmation, setShowConfirmation] = useState(false);
     const containerRef = useRef(null);
+
+    // Resolve combined Fly/Pop dynamically based on current coordinates
+    const getResolvedActionType = () => {
+        if (initialActionType !== "Fly/Pop Out") return initialActionType;
+        if (hitCoordinates.x === null || hitCoordinates.y === null) {
+            return "Fly Out"; // Default before click/hover
+        }
+        const dx = hitCoordinates.x - ORIGIN_X;
+        const dy = ORIGIN_Y - hitCoordinates.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        return dist > DEPTH_THRESHOLD.INFIELD ? "Fly Out" : "Pop Out";
+    };
+
+    const actionType = getResolvedActionType();
 
     const hitLocation = getFieldZone(
         hitCoordinates.x,
@@ -102,15 +117,26 @@ export default function DesktopPlayActionDrawer({
         const constrainedX = Math.max(0, Math.min(100, x));
         const constrainedY = Math.max(0, Math.min(100, y));
 
-        // Handle hit boundaries and HR floors
+        // Handle hit boundaries and HR floors (pass initialActionType so Fly/Pop Out allows full range)
         const { x: finalX, y: finalY } = getClampedCoordinates(
             constrainedX,
             constrainedY,
-            actionType,
+            initialActionType,
         );
 
+        // Resolve action type dynamically from pointer coordinates
+        const dx = finalX - ORIGIN_X;
+        const dy = ORIGIN_Y - finalY;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        const resolvedType =
+            initialActionType === "Fly/Pop Out"
+                ? dist > DEPTH_THRESHOLD.INFIELD
+                    ? "Fly Out"
+                    : "Pop Out"
+                : initialActionType;
+
         // Only update if it's fair territory
-        const location = getFieldZone(finalX, finalY, actionType);
+        const location = getFieldZone(finalX, finalY, resolvedType);
         if (location === "foul ball") return false;
 
         setHitCoordinates({ x: finalX, y: finalY });
@@ -122,7 +148,7 @@ export default function DesktopPlayActionDrawer({
         // For Fly Outs, only outfielders catch them.
         // For Pop Outs and others, anyone can be the fielder.
         const snapPositions =
-            actionType === "Fly Out"
+            resolvedType === "Fly Out"
                 ? positions.filter((p) =>
                       ["LF", "LC", "RC", "RF"].includes(p.value),
                   )

--- a/app/routes/gameday/components/DesktopPlayActionDrawer.jsx
+++ b/app/routes/gameday/components/DesktopPlayActionDrawer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/set-state-in-effect */
 import { useState, useRef, useEffect } from "react";
 import {
     Avatar,
@@ -22,11 +23,12 @@ import FieldHighlight from "./FieldHighlight";
 
 import { useRunnerProjection } from "../hooks/useRunnerProjection";
 import { getDrawerTitle, getActionColor } from "../utils/drawerUtils";
-import { ORIGIN_X, ORIGIN_Y, DEPTH_THRESHOLD } from "@/constants/fieldMapping";
+import { UI_KEYS } from "@/constants/scoring";
 import {
     getFieldZone,
     getClampedCoordinates,
     getRelativePointerCoordinates,
+    resolveFlyPopOut,
 } from "../utils/fieldMapping";
 import ConfirmationPanel from "./ConfirmationPanel";
 
@@ -54,14 +56,8 @@ export default function DesktopPlayActionDrawer({
 
     // Resolve combined Fly/Pop dynamically based on current coordinates
     const getResolvedActionType = () => {
-        if (initialActionType !== "Fly/Pop Out") return initialActionType;
-        if (hitCoordinates.x === null || hitCoordinates.y === null) {
-            return "Fly Out"; // Default before click/hover
-        }
-        const dx = hitCoordinates.x - ORIGIN_X;
-        const dy = ORIGIN_Y - hitCoordinates.y;
-        const dist = Math.sqrt(dx * dx + dy * dy);
-        return dist > DEPTH_THRESHOLD.INFIELD ? "Fly Out" : "Pop Out";
+        if (initialActionType !== UI_KEYS.FLY_POP) return initialActionType;
+        return resolveFlyPopOut(hitCoordinates.x, hitCoordinates.y);
     };
 
     const actionType = getResolvedActionType();
@@ -125,14 +121,9 @@ export default function DesktopPlayActionDrawer({
         );
 
         // Resolve action type dynamically from pointer coordinates
-        const dx = finalX - ORIGIN_X;
-        const dy = ORIGIN_Y - finalY;
-        const dist = Math.sqrt(dx * dx + dy * dy);
         const resolvedType =
-            initialActionType === "Fly/Pop Out"
-                ? dist > DEPTH_THRESHOLD.INFIELD
-                    ? "Fly Out"
-                    : "Pop Out"
+            initialActionType === UI_KEYS.FLY_POP
+                ? resolveFlyPopOut(finalX, finalY)
                 : initialActionType;
 
         // Only update if it's fair territory

--- a/app/routes/gameday/components/DesktopPlayActionDrawer.jsx
+++ b/app/routes/gameday/components/DesktopPlayActionDrawer.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/set-state-in-effect */
 import { useState, useRef, useEffect } from "react";
 import {
     Avatar,
@@ -84,6 +83,7 @@ export default function DesktopPlayActionDrawer({
     }));
 
     // Reset state when drawer closes
+    /* eslint-disable react-hooks/set-state-in-effect */
     useEffect(() => {
         if (!opened) {
             setSelectedPosition(null);
@@ -93,6 +93,7 @@ export default function DesktopPlayActionDrawer({
             setShowConfirmation(false);
         }
     }, [opened, bats]);
+    /* eslint-enable react-hooks/set-state-in-effect */
 
     const handleConfirm = () => {
         onSelect({

--- a/app/routes/gameday/components/DesktopPlayActionDrawer.jsx
+++ b/app/routes/gameday/components/DesktopPlayActionDrawer.jsx
@@ -56,6 +56,9 @@ export default function DesktopPlayActionDrawer({
     // Resolve combined Fly/Pop dynamically based on current coordinates
     const getResolvedActionType = () => {
         if (initialActionType !== UI_KEYS.FLY_POP) return initialActionType;
+        if (hitCoordinates.x == null || hitCoordinates.y == null) {
+            return UI_KEYS.FLY_POP;
+        }
         return resolveFlyPopOut(hitCoordinates.x, hitCoordinates.y);
     };
 

--- a/app/routes/gameday/components/EditPlayDrawer.jsx
+++ b/app/routes/gameday/components/EditPlayDrawer.jsx
@@ -168,28 +168,40 @@ export default function EditPlayDrawer({
         [batter],
     );
 
+    // Resolve combined Fly/Pop dynamically based on current coordinates
+    const resolvedEventType = useMemo(() => {
+        if (eventType !== UI_KEYS.FLY_POP) return eventType;
+        return resolveFlyPopOut(hitCoordinates.x, hitCoordinates.y);
+    }, [eventType, hitCoordinates]);
+
     // Full zone string derived from coordinates (e.g. "deep right-center gap")
     const hitLocation = useMemo(() => {
         if (hitCoordinates.x == null || hitCoordinates.y == null) return null;
         const zone = getFieldZone(
             hitCoordinates.x,
             hitCoordinates.y,
-            eventType,
+            resolvedEventType,
         );
         return zone && zone !== "foul ball" ? zone : null;
-    }, [hitCoordinates, eventType]);
+    }, [hitCoordinates, resolvedEventType]);
 
     // Description is fully derived from current play state
     const description = useMemo(() => {
-        if (!eventType || !batterName) return "";
+        if (!resolvedEventType || !batterName) return "";
         return getEventDescription(
-            eventType,
+            resolvedEventType,
             batterName,
             selectedPosition,
             runnerResults,
             hitLocation,
         );
-    }, [eventType, selectedPosition, runnerResults, batterName, hitLocation]);
+    }, [
+        resolvedEventType,
+        selectedPosition,
+        runnerResults,
+        batterName,
+        hitLocation,
+    ]);
 
     // Starting runners (Pre-play)
     const startingRunners = useMemo(() => {
@@ -325,15 +337,6 @@ export default function EditPlayDrawer({
                 derivedBaseState[outcome] = pId;
             }
         });
-
-        // Resolve Fly/Pop Out eventType
-        let resolvedEventType = eventType;
-        if (eventType === UI_KEYS.FLY_POP) {
-            resolvedEventType = resolveFlyPopOut(
-                hitCoordinates.x,
-                hitCoordinates.y,
-            );
-        }
 
         onSave(log.$id, {
             eventType: EVENT_TYPE_MAP[resolvedEventType] || resolvedEventType,

--- a/app/routes/gameday/components/EditPlayDrawer.jsx
+++ b/app/routes/gameday/components/EditPlayDrawer.jsx
@@ -171,6 +171,9 @@ export default function EditPlayDrawer({
     // Resolve combined Fly/Pop dynamically based on current coordinates
     const resolvedEventType = useMemo(() => {
         if (eventType !== UI_KEYS.FLY_POP) return eventType;
+        if (hitCoordinates.x == null || hitCoordinates.y == null) {
+            return eventType;
+        }
         return resolveFlyPopOut(hitCoordinates.x, hitCoordinates.y);
     }, [eventType, hitCoordinates]);
 
@@ -306,6 +309,10 @@ export default function EditPlayDrawer({
         });
         setSelectedPosition(nearestPos);
     };
+
+    const isSaveDisabled =
+        eventType === UI_KEYS.FLY_POP &&
+        (hitCoordinates.x == null || hitCoordinates.y == null);
 
     const handleSave = () => {
         if (!log) return;
@@ -445,6 +452,12 @@ export default function EditPlayDrawer({
                     />
                 </Group>
             </Paper>
+            {isSaveDisabled && (
+                <Text size="xs" c="orange" fw={600} ta="center" mt="xs">
+                    Please select a hit location to resolve the Fly/Pop Out
+                    before saving.
+                </Text>
+            )}
 
             <Divider mt="sm" />
 
@@ -699,6 +712,7 @@ export default function EditPlayDrawer({
                             fw={800}
                             onClick={handleSave}
                             loading={isSubmitting}
+                            disabled={isSaveDisabled}
                         >
                             Save Changes
                         </Button>

--- a/app/routes/gameday/components/EditPlayDrawer.jsx
+++ b/app/routes/gameday/components/EditPlayDrawer.jsx
@@ -31,6 +31,7 @@ import {
     getClampedCoordinates,
     getRelativePointerCoordinates,
 } from "../utils/fieldMapping";
+import { ORIGIN_X, ORIGIN_Y, DEPTH_THRESHOLD } from "@/constants/fieldMapping";
 
 import DrawerContainer from "@/components/DrawerContainer/DrawerContainer";
 
@@ -325,8 +326,22 @@ export default function EditPlayDrawer({
             }
         });
 
+        // Resolve Fly/Pop Out eventType
+        let resolvedEventType = eventType;
+        if (eventType === "Fly/Pop Out" || eventType === "Fly/Pop") {
+            if (hitCoordinates.x !== null && hitCoordinates.y !== null) {
+                const dx = hitCoordinates.x - ORIGIN_X;
+                const dy = ORIGIN_Y - hitCoordinates.y;
+                const dist = Math.sqrt(dx * dx + dy * dy);
+                resolvedEventType =
+                    dist > DEPTH_THRESHOLD.INFIELD ? "Fly Out" : "Pop Out";
+            } else {
+                resolvedEventType = "Fly Out";
+            }
+        }
+
         onSave(log.$id, {
-            eventType: EVENT_TYPE_MAP[eventType] || eventType,
+            eventType: EVENT_TYPE_MAP[resolvedEventType] || resolvedEventType,
             rbi: runnersModified ? runsScored : log.rbi,
             outsOnPlay: runnersModified ? outsRecorded : log.outsOnPlay,
             description,

--- a/app/routes/gameday/components/EditPlayDrawer.jsx
+++ b/app/routes/gameday/components/EditPlayDrawer.jsx
@@ -19,7 +19,7 @@ import {
     IconUsers,
     IconWriting,
 } from "@tabler/icons-react";
-import { getUILabel, EVENT_TYPE_MAP } from "@/constants/scoring";
+import { getUILabel, EVENT_TYPE_MAP, UI_KEYS } from "@/constants/scoring";
 import POSITIONS from "@/constants/positions";
 import images from "@/constants/images";
 
@@ -30,8 +30,8 @@ import {
     getFieldZone,
     getClampedCoordinates,
     getRelativePointerCoordinates,
+    resolveFlyPopOut,
 } from "../utils/fieldMapping";
-import { ORIGIN_X, ORIGIN_Y, DEPTH_THRESHOLD } from "@/constants/fieldMapping";
 
 import DrawerContainer from "@/components/DrawerContainer/DrawerContainer";
 
@@ -328,16 +328,11 @@ export default function EditPlayDrawer({
 
         // Resolve Fly/Pop Out eventType
         let resolvedEventType = eventType;
-        if (eventType === "Fly/Pop Out" || eventType === "Fly/Pop") {
-            if (hitCoordinates.x !== null && hitCoordinates.y !== null) {
-                const dx = hitCoordinates.x - ORIGIN_X;
-                const dy = ORIGIN_Y - hitCoordinates.y;
-                const dist = Math.sqrt(dx * dx + dy * dy);
-                resolvedEventType =
-                    dist > DEPTH_THRESHOLD.INFIELD ? "Fly Out" : "Pop Out";
-            } else {
-                resolvedEventType = "Fly Out";
-            }
+        if (eventType === UI_KEYS.FLY_POP) {
+            resolvedEventType = resolveFlyPopOut(
+                hitCoordinates.x,
+                hitCoordinates.y,
+            );
         }
 
         onSave(log.$id, {

--- a/app/routes/gameday/components/MobilePlayActionDrawer.jsx
+++ b/app/routes/gameday/components/MobilePlayActionDrawer.jsx
@@ -22,6 +22,7 @@ import FieldHighlight from "./FieldHighlight";
 
 import { useRunnerProjection } from "../hooks/useRunnerProjection";
 import { getDrawerTitle, getActionColor } from "../utils/drawerUtils";
+import { ORIGIN_X, ORIGIN_Y, DEPTH_THRESHOLD } from "@/constants/fieldMapping";
 import {
     getFieldZone,
     getClampedCoordinates,
@@ -33,7 +34,7 @@ export default function MobilePlayActionDrawer({
     opened,
     onClose,
     onSelect,
-    actionType,
+    actionType: initialActionType,
     runners,
     playerChart,
     currentBatter,
@@ -49,6 +50,20 @@ export default function MobilePlayActionDrawer({
     const [hitCoordinates, setHitCoordinates] = useState({ x: null, y: null });
     const [isDragging, setIsDragging] = useState(false);
     const containerRef = useRef(null);
+
+    // Resolve combined Fly/Pop dynamically based on current coordinates
+    const getResolvedActionType = () => {
+        if (initialActionType !== "Fly/Pop Out") return initialActionType;
+        if (hitCoordinates.x === null || hitCoordinates.y === null) {
+            return "Fly Out"; // Default before click/hover
+        }
+        const dx = hitCoordinates.x - ORIGIN_X;
+        const dy = ORIGIN_Y - hitCoordinates.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        return dist > DEPTH_THRESHOLD.INFIELD ? "Fly Out" : "Pop Out";
+    };
+
+    const actionType = getResolvedActionType();
 
     const hitLocation = getFieldZone(
         hitCoordinates.x,
@@ -99,15 +114,26 @@ export default function MobilePlayActionDrawer({
         const constrainedX = Math.max(0, Math.min(100, x));
         const constrainedY = Math.max(0, Math.min(100, y));
 
-        // Handle hit boundaries and HR floors
+        // Handle hit boundaries and HR floors (pass initialActionType so Fly/Pop Out allows full range)
         const { x: finalX, y: finalY } = getClampedCoordinates(
             constrainedX,
             constrainedY,
-            actionType,
+            initialActionType,
         );
 
+        // Resolve action type dynamically from pointer coordinates
+        const dx = finalX - ORIGIN_X;
+        const dy = ORIGIN_Y - finalY;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        const resolvedType =
+            initialActionType === "Fly/Pop Out"
+                ? dist > DEPTH_THRESHOLD.INFIELD
+                    ? "Fly Out"
+                    : "Pop Out"
+                : initialActionType;
+
         // Only update if it's fair territory
-        const location = getFieldZone(finalX, finalY, actionType);
+        const location = getFieldZone(finalX, finalY, resolvedType);
         if (location === "foul ball") return false;
 
         setHitCoordinates({ x: finalX, y: finalY });
@@ -119,7 +145,7 @@ export default function MobilePlayActionDrawer({
         // For Fly Outs, only outfielders catch them.
         // For Pop Outs and others, anyone can be the fielder.
         const snapPositions =
-            actionType === "Fly Out"
+            resolvedType === "Fly Out"
                 ? positions.filter((p) =>
                       ["LF", "LC", "RC", "RF"].includes(p.value),
                   )

--- a/app/routes/gameday/components/MobilePlayActionDrawer.jsx
+++ b/app/routes/gameday/components/MobilePlayActionDrawer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/set-state-in-effect */
 import { useState, useRef, useEffect } from "react";
 import {
     Avatar,
@@ -22,11 +23,12 @@ import FieldHighlight from "./FieldHighlight";
 
 import { useRunnerProjection } from "../hooks/useRunnerProjection";
 import { getDrawerTitle, getActionColor } from "../utils/drawerUtils";
-import { ORIGIN_X, ORIGIN_Y, DEPTH_THRESHOLD } from "@/constants/fieldMapping";
+import { UI_KEYS } from "@/constants/scoring";
 import {
     getFieldZone,
     getClampedCoordinates,
     getRelativePointerCoordinates,
+    resolveFlyPopOut,
 } from "../utils/fieldMapping";
 import ConfirmationPanel from "./ConfirmationPanel";
 
@@ -53,14 +55,8 @@ export default function MobilePlayActionDrawer({
 
     // Resolve combined Fly/Pop dynamically based on current coordinates
     const getResolvedActionType = () => {
-        if (initialActionType !== "Fly/Pop Out") return initialActionType;
-        if (hitCoordinates.x === null || hitCoordinates.y === null) {
-            return "Fly Out"; // Default before click/hover
-        }
-        const dx = hitCoordinates.x - ORIGIN_X;
-        const dy = ORIGIN_Y - hitCoordinates.y;
-        const dist = Math.sqrt(dx * dx + dy * dy);
-        return dist > DEPTH_THRESHOLD.INFIELD ? "Fly Out" : "Pop Out";
+        if (initialActionType !== UI_KEYS.FLY_POP) return initialActionType;
+        return resolveFlyPopOut(hitCoordinates.x, hitCoordinates.y);
     };
 
     const actionType = getResolvedActionType();
@@ -122,14 +118,9 @@ export default function MobilePlayActionDrawer({
         );
 
         // Resolve action type dynamically from pointer coordinates
-        const dx = finalX - ORIGIN_X;
-        const dy = ORIGIN_Y - finalY;
-        const dist = Math.sqrt(dx * dx + dy * dy);
         const resolvedType =
-            initialActionType === "Fly/Pop Out"
-                ? dist > DEPTH_THRESHOLD.INFIELD
-                    ? "Fly Out"
-                    : "Pop Out"
+            initialActionType === UI_KEYS.FLY_POP
+                ? resolveFlyPopOut(finalX, finalY)
                 : initialActionType;
 
         // Only update if it's fair territory

--- a/app/routes/gameday/components/MobilePlayActionDrawer.jsx
+++ b/app/routes/gameday/components/MobilePlayActionDrawer.jsx
@@ -55,6 +55,9 @@ export default function MobilePlayActionDrawer({
     // Resolve combined Fly/Pop dynamically based on current coordinates
     const getResolvedActionType = () => {
         if (initialActionType !== UI_KEYS.FLY_POP) return initialActionType;
+        if (hitCoordinates.x == null || hitCoordinates.y == null) {
+            return UI_KEYS.FLY_POP;
+        }
         return resolveFlyPopOut(hitCoordinates.x, hitCoordinates.y);
     };
 

--- a/app/routes/gameday/components/MobilePlayActionDrawer.jsx
+++ b/app/routes/gameday/components/MobilePlayActionDrawer.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/set-state-in-effect */
 import { useState, useRef, useEffect } from "react";
 import {
     Avatar,
@@ -83,6 +82,7 @@ export default function MobilePlayActionDrawer({
     }));
 
     // Reset local state when drawer closes
+    /* eslint-disable react-hooks/set-state-in-effect */
     useEffect(() => {
         if (!opened) {
             setSelectedPosition(null);
@@ -90,6 +90,7 @@ export default function MobilePlayActionDrawer({
             setBattingSide(bats || "right");
         }
     }, [opened, bats]);
+    /* eslint-enable react-hooks/set-state-in-effect */
 
     const handleConfirm = () => {
         onSelect({

--- a/app/routes/gameday/components/tests/ActionPad.test.jsx
+++ b/app/routes/gameday/components/tests/ActionPad.test.jsx
@@ -37,11 +37,12 @@ describe("ActionPad", () => {
         );
         expect(screen.getByRole("button", { name: "K" })).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "GRD" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "FLY" })).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "FLY/POP" }),
+        ).toBeInTheDocument();
         expect(
             screen.getByRole("button", { name: "LINE" }),
         ).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "POP" })).toBeInTheDocument();
     });
 
     it("calls onAction with correct value when button is clicked", () => {

--- a/app/routes/gameday/components/tests/DesktopPlayActionDrawer.test.jsx
+++ b/app/routes/gameday/components/tests/DesktopPlayActionDrawer.test.jsx
@@ -1,4 +1,6 @@
+/* eslint-disable react/display-name */
 import { render, screen, fireEvent } from "@/utils/test-utils";
+import { UI_KEYS } from "@/constants/scoring";
 
 import * as runnerProjectionHook from "../../hooks/useRunnerProjection";
 import * as drawerUtils from "../../utils/drawerUtils";
@@ -30,6 +32,13 @@ jest.mock("../../utils/fieldMapping", () => ({
     getFieldZone: jest.fn().mockReturnValue("left field"),
     getClampedCoordinates: jest.fn().mockImplementation((x, y) => ({ x, y })),
     getRelativePointerCoordinates: jest.fn().mockReturnValue({ x: 50, y: 50 }),
+    resolveFlyPopOut: jest.fn().mockImplementation((x, y) => {
+        if (x === null || y === null) return "Fly Out";
+        const dx = x - 50;
+        const dy = 78 - y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        return dist > 38 ? "Fly Out" : "Pop Out";
+    }),
 }));
 
 jest.mock("../ConfirmationPanel", () => (props) => (
@@ -150,7 +159,7 @@ describe("DesktopPlayActionDrawer", () => {
         const { unmount } = render(
             <DesktopPlayActionDrawer
                 {...defaultProps}
-                actionType="Fly/Pop Out"
+                actionType={UI_KEYS.FLY_POP}
                 onSelect={mockOnSelectOutfield}
             />,
         );
@@ -180,7 +189,7 @@ describe("DesktopPlayActionDrawer", () => {
         render(
             <DesktopPlayActionDrawer
                 {...defaultProps}
-                actionType="Fly/Pop Out"
+                actionType={UI_KEYS.FLY_POP}
                 onSelect={mockOnSelectInfield}
             />,
         );

--- a/app/routes/gameday/components/tests/DesktopPlayActionDrawer.test.jsx
+++ b/app/routes/gameday/components/tests/DesktopPlayActionDrawer.test.jsx
@@ -136,4 +136,68 @@ describe("DesktopPlayActionDrawer", () => {
             }),
         );
     });
+
+    it("resolves Fly/Pop Out to Fly Out or Pop Out based on interaction coordinates", async () => {
+        const fieldMapping = require("../../utils/fieldMapping");
+
+        // 1. Outfield coordinate
+        fieldMapping.getRelativePointerCoordinates.mockReturnValueOnce({
+            x: 50,
+            y: 20,
+        });
+
+        const mockOnSelectOutfield = jest.fn();
+        const { unmount } = render(
+            <DesktopPlayActionDrawer
+                {...defaultProps}
+                actionType="Fly/Pop Out"
+                onSelect={mockOnSelectOutfield}
+            />,
+        );
+
+        const fieldImage = screen.getByAltText(
+            /Interactive softball field diagram/i,
+        );
+        const container = fieldImage.parentElement;
+
+        fireEvent.pointerDown(container, {
+            clientX: 100,
+            clientY: 100,
+            pointerId: 1,
+        });
+        fireEvent.click(screen.getByText(/Proceed to Runner Advancement/i));
+        fireEvent.click(screen.getByText("Confirm Play"));
+
+        expect(mockOnSelectOutfield).toHaveBeenCalled();
+        unmount();
+
+        // 2. Infield coordinate
+        fieldMapping.getRelativePointerCoordinates.mockReturnValueOnce({
+            x: 50,
+            y: 65,
+        });
+        const mockOnSelectInfield = jest.fn();
+        render(
+            <DesktopPlayActionDrawer
+                {...defaultProps}
+                actionType="Fly/Pop Out"
+                onSelect={mockOnSelectInfield}
+            />,
+        );
+
+        const fieldImage2 = screen.getByAltText(
+            /Interactive softball field diagram/i,
+        );
+        const container2 = fieldImage2.parentElement;
+
+        fireEvent.pointerDown(container2, {
+            clientX: 100,
+            clientY: 100,
+            pointerId: 1,
+        });
+        fireEvent.click(screen.getByText(/Proceed to Runner Advancement/i));
+        fireEvent.click(screen.getByText("Confirm Play"));
+
+        expect(mockOnSelectInfield).toHaveBeenCalled();
+    });
 });

--- a/app/routes/gameday/components/tests/EditPlayDrawer.test.jsx
+++ b/app/routes/gameday/components/tests/EditPlayDrawer.test.jsx
@@ -292,6 +292,9 @@ describe("EditPlayDrawer", () => {
             expect(onSaveMock).toHaveBeenCalledTimes(1);
             const [, payload] = onSaveMock.mock.calls[0];
             expect(payload.eventType).toBe("fly_out");
+            expect(payload.description).toBe(
+                "Joseph Gordy flies out to deep center field",
+            );
         });
 
         it("resolves Fly/Pop Out to Pop Out (pop_out) for infield coordinates", () => {
@@ -323,6 +326,9 @@ describe("EditPlayDrawer", () => {
             expect(onSaveMock).toHaveBeenCalledTimes(1);
             const [, payload] = onSaveMock.mock.calls[0];
             expect(payload.eventType).toBe("pop_out");
+            expect(payload.description).toBe(
+                "Joseph Gordy pops out to back to the pitcher",
+            );
         });
 
         it("shows loading state while isSubmitting", () => {

--- a/app/routes/gameday/components/tests/EditPlayDrawer.test.jsx
+++ b/app/routes/gameday/components/tests/EditPlayDrawer.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from "@/utils/test-utils";
+import { UI_KEYS } from "@/constants/scoring";
 import EditPlayDrawer from "../EditPlayDrawer";
 
 // Heavy sub-components that have their own test suites
@@ -281,7 +282,7 @@ describe("EditPlayDrawer", () => {
             fireEvent.click(screen.getByText("Change Result"));
             // Click Fly/Pop Out
             fireEvent.click(
-                screen.getByRole("button", { name: "Fly/Pop Out" }),
+                screen.getByRole("button", { name: UI_KEYS.FLY_POP }),
             );
             // Save Changes
             fireEvent.click(
@@ -312,7 +313,7 @@ describe("EditPlayDrawer", () => {
             fireEvent.click(screen.getByText("Change Result"));
             // Click Fly/Pop Out
             fireEvent.click(
-                screen.getByRole("button", { name: "Fly/Pop Out" }),
+                screen.getByRole("button", { name: UI_KEYS.FLY_POP }),
             );
             // Save Changes
             fireEvent.click(

--- a/app/routes/gameday/components/tests/EditPlayDrawer.test.jsx
+++ b/app/routes/gameday/components/tests/EditPlayDrawer.test.jsx
@@ -31,6 +31,9 @@ jest.mock("../ActionPad", () => ({
             <button onClick={() => onAction && onAction("2B")}>2B</button>
             <button onClick={() => onAction && onAction("K")}>K</button>
             <button onClick={() => onAction && onAction("1B")}>1B</button>
+            <button onClick={() => onAction && onAction("Fly/Pop Out")}>
+                Fly/Pop Out
+            </button>
         </div>
     ),
 }));
@@ -257,6 +260,68 @@ describe("EditPlayDrawer", () => {
             const [, payload] = defaultProps.onSave.mock.calls[0];
             expect(typeof payload.hitX).toBe("number");
             expect(typeof payload.hitY).toBe("number");
+        });
+
+        it("resolves Fly/Pop Out to Fly Out (fly_out) for outfield coordinates", () => {
+            const outfieldLog = {
+                ...mockLog,
+                hitX: 50.0,
+                hitY: 20.0, // distance = 58 > 38
+            };
+            const onSaveMock = jest.fn();
+            render(
+                <EditPlayDrawer
+                    {...defaultProps}
+                    log={outfieldLog}
+                    onSave={onSaveMock}
+                />,
+            );
+
+            // Navigate to change result
+            fireEvent.click(screen.getByText("Change Result"));
+            // Click Fly/Pop Out
+            fireEvent.click(
+                screen.getByRole("button", { name: "Fly/Pop Out" }),
+            );
+            // Save Changes
+            fireEvent.click(
+                screen.getByRole("button", { name: /Save Changes/i }),
+            );
+
+            expect(onSaveMock).toHaveBeenCalledTimes(1);
+            const [, payload] = onSaveMock.mock.calls[0];
+            expect(payload.eventType).toBe("fly_out");
+        });
+
+        it("resolves Fly/Pop Out to Pop Out (pop_out) for infield coordinates", () => {
+            const infieldLog = {
+                ...mockLog,
+                hitX: 50.0,
+                hitY: 65.0, // distance = 13 < 38
+            };
+            const onSaveMock = jest.fn();
+            render(
+                <EditPlayDrawer
+                    {...defaultProps}
+                    log={infieldLog}
+                    onSave={onSaveMock}
+                />,
+            );
+
+            // Navigate to change result
+            fireEvent.click(screen.getByText("Change Result"));
+            // Click Fly/Pop Out
+            fireEvent.click(
+                screen.getByRole("button", { name: "Fly/Pop Out" }),
+            );
+            // Save Changes
+            fireEvent.click(
+                screen.getByRole("button", { name: /Save Changes/i }),
+            );
+
+            expect(onSaveMock).toHaveBeenCalledTimes(1);
+            const [, payload] = onSaveMock.mock.calls[0];
+            expect(payload.eventType).toBe("pop_out");
         });
 
         it("shows loading state while isSubmitting", () => {

--- a/app/routes/gameday/components/tests/MobilePlayActionDrawer.test.jsx
+++ b/app/routes/gameday/components/tests/MobilePlayActionDrawer.test.jsx
@@ -1,4 +1,6 @@
+/* eslint-disable react/display-name */
 import { render, screen, fireEvent } from "@/utils/test-utils";
+import { UI_KEYS } from "@/constants/scoring";
 
 import * as runnerProjectionHook from "../../hooks/useRunnerProjection";
 import * as drawerUtils from "../../utils/drawerUtils";
@@ -30,6 +32,13 @@ jest.mock("../../utils/fieldMapping", () => ({
     getFieldZone: jest.fn().mockReturnValue("left field"),
     getClampedCoordinates: jest.fn().mockImplementation((x, y) => ({ x, y })),
     getRelativePointerCoordinates: jest.fn().mockReturnValue({ x: 50, y: 50 }),
+    resolveFlyPopOut: jest.fn().mockImplementation((x, y) => {
+        if (x === null || y === null) return "Fly Out";
+        const dx = x - 50;
+        const dy = 78 - y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        return dist > 38 ? "Fly Out" : "Pop Out";
+    }),
 }));
 jest.mock("../ConfirmationPanel", () => (props) => (
     <div data-testid="confirmation-panel">
@@ -130,7 +139,7 @@ describe("MobilePlayActionDrawer", () => {
         );
     });
 
-    it("resolves Fly/Pop Out to Fly Out or Pop Out based on interaction coordinates on mobile", async () => {
+    it("resolves Fly/Pop Out to Fly Out or Pop Out based on interaction coordinates", async () => {
         const fieldMapping = require("../../utils/fieldMapping");
 
         // 1. Outfield coordinate
@@ -143,7 +152,7 @@ describe("MobilePlayActionDrawer", () => {
         const { unmount } = render(
             <MobilePlayActionDrawer
                 {...defaultProps}
-                actionType="Fly/Pop Out"
+                actionType={UI_KEYS.FLY_POP}
                 onSelect={mockOnSelectOutfield}
             />,
         );
@@ -173,7 +182,7 @@ describe("MobilePlayActionDrawer", () => {
         render(
             <MobilePlayActionDrawer
                 {...defaultProps}
-                actionType="Fly/Pop Out"
+                actionType={UI_KEYS.FLY_POP}
                 onSelect={mockOnSelectInfield}
             />,
         );

--- a/app/routes/gameday/components/tests/MobilePlayActionDrawer.test.jsx
+++ b/app/routes/gameday/components/tests/MobilePlayActionDrawer.test.jsx
@@ -129,4 +129,68 @@ describe("MobilePlayActionDrawer", () => {
             }),
         );
     });
+
+    it("resolves Fly/Pop Out to Fly Out or Pop Out based on interaction coordinates on mobile", async () => {
+        const fieldMapping = require("../../utils/fieldMapping");
+
+        // 1. Outfield coordinate
+        fieldMapping.getRelativePointerCoordinates.mockReturnValueOnce({
+            x: 50,
+            y: 20,
+        });
+
+        const mockOnSelectOutfield = jest.fn();
+        const { unmount } = render(
+            <MobilePlayActionDrawer
+                {...defaultProps}
+                actionType="Fly/Pop Out"
+                onSelect={mockOnSelectOutfield}
+            />,
+        );
+
+        const fieldImage = screen.getByAltText(
+            /Interactive softball field diagram/i,
+        );
+        const container = fieldImage.parentElement;
+
+        fireEvent.pointerDown(container, {
+            clientX: 100,
+            clientY: 100,
+            pointerId: 1,
+        });
+        fireEvent.pointerUp(container);
+        fireEvent.click(screen.getByText("Confirm Play"));
+
+        expect(mockOnSelectOutfield).toHaveBeenCalled();
+        unmount();
+
+        // 2. Infield coordinate
+        fieldMapping.getRelativePointerCoordinates.mockReturnValueOnce({
+            x: 50,
+            y: 65,
+        });
+        const mockOnSelectInfield = jest.fn();
+        render(
+            <MobilePlayActionDrawer
+                {...defaultProps}
+                actionType="Fly/Pop Out"
+                onSelect={mockOnSelectInfield}
+            />,
+        );
+
+        const fieldImage2 = screen.getByAltText(
+            /Interactive softball field diagram/i,
+        );
+        const container2 = fieldImage2.parentElement;
+
+        fireEvent.pointerDown(container2, {
+            clientX: 100,
+            clientY: 100,
+            pointerId: 1,
+        });
+        fireEvent.pointerUp(container2);
+        fireEvent.click(screen.getByText("Confirm Play"));
+
+        expect(mockOnSelectInfield).toHaveBeenCalled();
+    });
 });

--- a/app/routes/gameday/hooks/tests/useGamedayActions.test.jsx
+++ b/app/routes/gameday/hooks/tests/useGamedayActions.test.jsx
@@ -153,6 +153,42 @@ describe("useGamedayActions", () => {
         expect(defaultProps.setBattingOrderIndex).toHaveBeenCalledWith(1);
     });
 
+    it("resolves Fly/Pop Out to Fly Out or Pop Out based on payload coordinates in completeAction", () => {
+        const { result } = renderHook(() => useGamedayActions(defaultProps));
+
+        // 1. Infield coordinates
+        act(() => {
+            result.current.completeAction("Fly/Pop Out", {
+                hitCoordinates: { x: 50, y: 65 },
+                hitLocation: "to shortstop",
+            });
+        });
+
+        expect(mockSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                _action: "log-game-event",
+                eventType: "Pop Out",
+            }),
+            { method: "post" },
+        );
+
+        // 2. Outfield coordinates
+        act(() => {
+            result.current.completeAction("Fly/Pop Out", {
+                hitCoordinates: { x: 50, y: 20 },
+                hitLocation: "center field",
+            });
+        });
+
+        expect(mockSubmit).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                _action: "log-game-event",
+                eventType: "Fly Out",
+            }),
+            { method: "post" },
+        );
+    });
+
     it("undoLast calls fetcher submit", () => {
         const logsWithEntry = [{ $id: "log123" }];
         const { result } = renderHook(() =>

--- a/app/routes/gameday/hooks/tests/useGamedayActions.test.jsx
+++ b/app/routes/gameday/hooks/tests/useGamedayActions.test.jsx
@@ -2,6 +2,7 @@ import { useFetcher } from "react-router";
 import { renderHook, act } from "@testing-library/react";
 
 import { useGamedayActions } from "../useGamedayActions";
+import { UI_KEYS } from "@/constants/scoring";
 
 jest.mock("react-router", () => ({
     useFetcher: jest.fn(),
@@ -158,7 +159,7 @@ describe("useGamedayActions", () => {
 
         // 1. Infield coordinates
         act(() => {
-            result.current.completeAction("Fly/Pop Out", {
+            result.current.completeAction(UI_KEYS.FLY_POP, {
                 hitCoordinates: { x: 50, y: 65 },
                 hitLocation: "to shortstop",
             });
@@ -174,7 +175,7 @@ describe("useGamedayActions", () => {
 
         // 2. Outfield coordinates
         act(() => {
-            result.current.completeAction("Fly/Pop Out", {
+            result.current.completeAction(UI_KEYS.FLY_POP, {
                 hitCoordinates: { x: 50, y: 20 },
                 hitLocation: "center field",
             });

--- a/app/routes/gameday/hooks/useGamedayActions.js
+++ b/app/routes/gameday/hooks/useGamedayActions.js
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { useFetcher } from "react-router";
 import { useDisclosure } from "@mantine/hooks";
 import { UI_BATTED_OUTS, UI_WALKS } from "@/constants/scoring";
+import { ORIGIN_X, ORIGIN_Y, DEPTH_THRESHOLD } from "@/constants/fieldMapping";
 import {
     getEventDescription,
     getActivePlayerInSlot,
@@ -157,7 +158,7 @@ export function useGamedayActions({
     }, [advanceHalfInning, outs, setOuts]);
 
     const completeAction = useCallback(
-        (actionType, payload = null) => {
+        (actionTypeInput, payload = null) => {
             const position = payload?.position || null;
             const runnerResults = payload?.runnerResults || null;
             const hitCoordinates = payload?.hitCoordinates || {
@@ -166,6 +167,20 @@ export function useGamedayActions({
             };
             const hitLocation = payload?.hitLocation || null;
             const battingSide = payload?.battingSide || "right";
+
+            // Resolve combined Fly/Pop Out
+            let actionType = actionTypeInput;
+            if (actionTypeInput === "Fly/Pop Out") {
+                if (hitCoordinates.x !== null && hitCoordinates.y !== null) {
+                    const dx = hitCoordinates.x - ORIGIN_X;
+                    const dy = ORIGIN_Y - hitCoordinates.y;
+                    const dist = Math.sqrt(dx * dx + dy * dy);
+                    actionType =
+                        dist > DEPTH_THRESHOLD.INFIELD ? "Fly Out" : "Pop Out";
+                } else {
+                    actionType = "Fly Out"; // Fallback
+                }
+            }
 
             // Resolve the active player for this slot (may be a substitute)
             const activePlayer = isOurBatting

--- a/app/routes/gameday/hooks/useGamedayActions.js
+++ b/app/routes/gameday/hooks/useGamedayActions.js
@@ -1,8 +1,8 @@
 import { useState, useCallback } from "react";
 import { useFetcher } from "react-router";
 import { useDisclosure } from "@mantine/hooks";
-import { UI_BATTED_OUTS, UI_WALKS } from "@/constants/scoring";
-import { ORIGIN_X, ORIGIN_Y, DEPTH_THRESHOLD } from "@/constants/fieldMapping";
+import { UI_BATTED_OUTS, UI_WALKS, UI_KEYS } from "@/constants/scoring";
+import { resolveFlyPopOut } from "../utils/fieldMapping";
 import {
     getEventDescription,
     getActivePlayerInSlot,
@@ -35,7 +35,7 @@ export function useGamedayActions({
     outs,
     setOuts,
     setScore,
-    opponentScore,
+    opponentScore: _opponentScore,
     setOpponentScore,
     runners,
     setRunners,
@@ -170,16 +170,11 @@ export function useGamedayActions({
 
             // Resolve combined Fly/Pop Out
             let actionType = actionTypeInput;
-            if (actionTypeInput === "Fly/Pop Out") {
-                if (hitCoordinates.x !== null && hitCoordinates.y !== null) {
-                    const dx = hitCoordinates.x - ORIGIN_X;
-                    const dy = ORIGIN_Y - hitCoordinates.y;
-                    const dist = Math.sqrt(dx * dx + dy * dy);
-                    actionType =
-                        dist > DEPTH_THRESHOLD.INFIELD ? "Fly Out" : "Pop Out";
-                } else {
-                    actionType = "Fly Out"; // Fallback
-                }
+            if (actionTypeInput === UI_KEYS.FLY_POP) {
+                actionType = resolveFlyPopOut(
+                    hitCoordinates.x,
+                    hitCoordinates.y,
+                );
             }
 
             // Resolve the active player for this slot (may be a substitute)

--- a/app/routes/gameday/utils/drawerUtils.js
+++ b/app/routes/gameday/utils/drawerUtils.js
@@ -27,6 +27,8 @@ export function getDrawerTitle(actionType, currentBatter) {
             return `${batterName} lines out to...`;
         case "Pop Out":
             return `${batterName} pops out to...`;
+        case "Fly/Pop Out":
+            return `${batterName} flies/pops out to...`;
         default:
             return `${batterName} - Select Position`;
     }

--- a/app/routes/gameday/utils/fieldMapping.js
+++ b/app/routes/gameday/utils/fieldMapping.js
@@ -145,6 +145,22 @@ export function getClampedCoordinates(x, y, actionType) {
 }
 
 /**
+ * Resolves a combined "Fly/Pop Out" play type to either "Fly Out" or "Pop Out"
+ * based on the distance of the hit from home plate.
+ *
+ * @param {number|null} x - The hit x coordinate
+ * @param {number|null} y - The hit y coordinate
+ * @returns {string} - "Fly Out" or "Pop Out"
+ */
+export function resolveFlyPopOut(x, y) {
+    if (x === null || y === null) return "Fly Out";
+    const dx = x - ORIGIN_X;
+    const dy = ORIGIN_Y - y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    return dist > DEPTH_THRESHOLD.INFIELD ? "Fly Out" : "Pop Out";
+}
+
+/**
  * Calculates percentage-based coordinates relative to a container from a pointer event.
  *
  * @param {PointerEvent|MouseEvent|TouchEvent} e - The native event

--- a/app/routes/gameday/utils/fieldMapping.js
+++ b/app/routes/gameday/utils/fieldMapping.js
@@ -153,7 +153,16 @@ export function getClampedCoordinates(x, y, actionType) {
  * @returns {string} - "Fly Out" or "Pop Out"
  */
 export function resolveFlyPopOut(x, y) {
-    if (x === null || y === null) return "Fly Out";
+    if (
+        x == null ||
+        y == null ||
+        typeof x !== "number" ||
+        typeof y !== "number" ||
+        isNaN(x) ||
+        isNaN(y)
+    ) {
+        return "Fly Out";
+    }
     const dx = x - ORIGIN_X;
     const dy = ORIGIN_Y - y;
     const dist = Math.sqrt(dx * dx + dy * dy);

--- a/app/routes/gameday/utils/tests/fieldMapping.test.js
+++ b/app/routes/gameday/utils/tests/fieldMapping.test.js
@@ -1,4 +1,8 @@
-import { getFieldZone, getClampedCoordinates } from "../fieldMapping";
+import {
+    getFieldZone,
+    getClampedCoordinates,
+    resolveFlyPopOut,
+} from "../fieldMapping";
 
 describe("getFieldZone", () => {
     it("should identify catcher location correctly", () => {
@@ -179,5 +183,29 @@ describe("getClampedCoordinates", () => {
         // Fly Out min is DEPTH_THRESHOLD.INFIELD (38).
         const result = getClampedCoordinates(50, 60, "Fly Out");
         expect(result.y).toBeCloseTo(39.9, 1); // 78 - 38.1 = 39.9
+    });
+});
+
+describe("resolveFlyPopOut", () => {
+    it("should default to 'Fly Out' if either coordinate is null", () => {
+        expect(resolveFlyPopOut(null, null)).toBe("Fly Out");
+        expect(resolveFlyPopOut(50, null)).toBe("Fly Out");
+        expect(resolveFlyPopOut(null, 78)).toBe("Fly Out");
+    });
+
+    it("should resolve to 'Pop Out' if within the infield depth threshold (distance <= 38)", () => {
+        // Click exactly at home plate: dist = 0
+        expect(resolveFlyPopOut(50, 78)).toBe("Pop Out");
+        // Click at pitcher's mound: x=50, y=60 (dist = 18 <= 38)
+        expect(resolveFlyPopOut(50, 60)).toBe("Pop Out");
+        // Click exactly at the infield/outfield boundary: x=50, y=40 (dist = 38 <= 38)
+        expect(resolveFlyPopOut(50, 40)).toBe("Pop Out");
+    });
+
+    it("should resolve to 'Fly Out' if beyond the infield depth threshold (distance > 38)", () => {
+        // Click slightly beyond the boundary: x=50, y=39 (dist = 39 > 38)
+        expect(resolveFlyPopOut(50, 39)).toBe("Fly Out");
+        // Click deep in center field: x=50, y=10 (dist = 68 > 38)
+        expect(resolveFlyPopOut(50, 10)).toBe("Fly Out");
     });
 });

--- a/app/routes/gameday/utils/tests/fieldMapping.test.js
+++ b/app/routes/gameday/utils/tests/fieldMapping.test.js
@@ -187,10 +187,16 @@ describe("getClampedCoordinates", () => {
 });
 
 describe("resolveFlyPopOut", () => {
-    it("should default to 'Fly Out' if either coordinate is null", () => {
+    it("should default to 'Fly Out' if coordinates are null, undefined, non-numeric, or NaN", () => {
         expect(resolveFlyPopOut(null, null)).toBe("Fly Out");
         expect(resolveFlyPopOut(50, null)).toBe("Fly Out");
         expect(resolveFlyPopOut(null, 78)).toBe("Fly Out");
+        expect(resolveFlyPopOut(undefined, undefined)).toBe("Fly Out");
+        expect(resolveFlyPopOut(50, undefined)).toBe("Fly Out");
+        expect(resolveFlyPopOut("50", 78)).toBe("Fly Out");
+        expect(resolveFlyPopOut(50, "78")).toBe("Fly Out");
+        expect(resolveFlyPopOut(NaN, 78)).toBe("Fly Out");
+        expect(resolveFlyPopOut(50, NaN)).toBe("Fly Out");
     });
 
     it("should resolve to 'Pop Out' if within the infield depth threshold (distance <= 38)", () => {


### PR DESCRIPTION
[![Render.com PR #195 ENV](https://img.shields.io/badge/Render.com%20PR%20%23195%20ENV-blue)](https://softball-manager-react-router-pr-195.onrender.com/)

This PR combines the separate FLY (Fly Out) and POP (Pop Out) scoring buttons on the Action Pad into a single combined 'FLY/POP' button. When clicked, the application dynamically resolves the play as a Fly Out or Pop Out based on the hit coordinates' distance from home plate.

All modified files are fully covered by comprehensive unit tests, and all 1,936 tests successfully pass!
