### PR TITLE
fix: Move Awards badge to the beginning of the interactive badge row on mobile

### DIFF
--- a/app/routes/events/components/MobileEventDetailsView.jsx
+++ b/app/routes/events/components/MobileEventDetailsView.jsx
@@ -81,6 +81,34 @@ export default function MobileEventDetailsView({
                 mt="md"
                 className={`${styles.badgeRow} tour-interactive-badge-row`}
             >
+                {/* Awards Badge (for past games) */}
+                {gameIsPast && game.eventType !== "practice" && (
+                    <Button
+                        variant="filled"
+                        color="blue"
+                        size="xs"
+                        radius="xl"
+                        onClick={() => {
+                            onOpenAwards();
+                            trackEvent("view-awards-badge", {
+                                eventId: game.$id,
+                            });
+                        }}
+                        leftSection={<IconTrophy size={16} />}
+                        data-testid="awards-badge-button"
+                        styles={{
+                            root: {
+                                cursor: "pointer",
+                                fontWeight: 600,
+                                border: "1.5px solid var(--mantine-color-lime-5)",
+                                flexShrink: 0,
+                            },
+                        }}
+                    >
+                        Awards
+                    </Button>
+                )}
+
                 {/* Weather Badge (for future games) */}
                 {!gameIsPast && (
                     <WeatherCard
@@ -244,34 +272,6 @@ export default function MobileEventDetailsView({
                         );
                     }}
                 </DeferredLoader>
-
-                {/* Awards Badge (for past games) */}
-                {gameIsPast && game.eventType !== "practice" && (
-                    <Button
-                        variant="filled"
-                        color="blue"
-                        size="xs"
-                        radius="xl"
-                        onClick={() => {
-                            onOpenAwards();
-                            trackEvent("view-awards-badge", {
-                                eventId: game.$id,
-                            });
-                        }}
-                        leftSection={<IconTrophy size={16} />}
-                        data-testid="awards-badge-button"
-                        styles={{
-                            root: {
-                                cursor: "pointer",
-                                fontWeight: 600,
-                                border: "1.5px solid var(--mantine-color-lime-5)",
-                                flexShrink: 0,
-                            },
-                        }}
-                    >
-                        Awards
-                    </Button>
-                )}
             </Group>
 
             <Box px="md">


### PR DESCRIPTION
[![Render.com PR #203 ENV](https://img.shields.io/badge/Render.com%20PR%20%23203%20ENV-blue)](https://softball-manager-react-router-pr-203.onrender.com/)


