### PR TITLE
feat(onboarding): track onboarding_tour_started when clicking Start Tour CTA

### DIFF
--- a/app/components/OnboardingTour/hooks/createTourEventHandler.js
+++ b/app/components/OnboardingTour/hooks/createTourEventHandler.js
@@ -222,6 +222,21 @@ export function createTourEventHandler({
         if (type === EVENTS.STEP_AFTER) {
             clearSelectTimeout();
 
+            if (data.index === 0 && data.action === "next") {
+                const suffix = trackingSuffix
+                    ? trackingSuffix.startsWith("_")
+                        ? trackingSuffix
+                        : `_${trackingSuffix}`
+                    : tourKey
+                      ? `_${tourKey.split("_")[0]}s`
+                      : "";
+
+                trackEvent(`onboarding_tour_started${suffix}`, {
+                    tourKey,
+                    userId: user?.$id || "anonymous",
+                });
+            }
+
             if (data.action === "next" || data.action === "prev") {
                 const nextIndex =
                     data.action === "prev" ? data.index - 1 : data.index + 1;

--- a/app/components/OnboardingTour/hooks/tests/createTourEventHandler.test.js
+++ b/app/components/OnboardingTour/hooks/tests/createTourEventHandler.test.js
@@ -143,6 +143,25 @@ describe("createTourEventHandler", () => {
         document.body.removeChild(actionBtn);
     });
 
+    it("tracks onboarding_tour_started when transitioning from step 0 with action next", () => {
+        const { result } = renderHook(() => createTourEventHandler(props));
+        const handleEvent = result.current;
+
+        handleEvent({
+            type: EVENTS.STEP_AFTER,
+            index: 0,
+            action: "next",
+        });
+
+        expect(trackEvent).toHaveBeenCalledWith(
+            "onboarding_tour_started_test",
+            expect.objectContaining({
+                tourKey: "test_tour",
+                userId: "user-123",
+            }),
+        );
+    });
+
     it("triggers analytics and saves completion on finished status", () => {
         const { result } = renderHook(() => createTourEventHandler(props));
         const handleEvent = result.current;


### PR DESCRIPTION
[![Render.com PR #206 ENV](https://img.shields.io/badge/Render.com%20PR%20%23206%20ENV-blue)](https://softball-manager-react-router-pr-206.onrender.com/)

This pull request adds analytics tracking for the "Start Tour" CTA button (on step 0/welcome step) across all onboarding tours. Other CTAs (like "Skip" and "Got it") are already covered via the skipped and completed event handlers.
