### PR TITLE
Adjust lineup mobile layout: move Scoring button to opponent row

### DIFF
--- a/app/routes/lineup/lineup.jsx
+++ b/app/routes/lineup/lineup.jsx
@@ -245,7 +245,7 @@ function Lineup({ loaderData, actionData }) {
             )}
             <Stack gap="md" mt="lg" mb="xl">
                 <Group justify="space-between" align="center">
-                    <BackButton text="Back to event details" />
+                    <BackButton text="Event Details" />
                     <Group align="center" gap="xs">
                         <ShareUrlButton />
                         {managerView && (
@@ -280,18 +280,6 @@ function Lineup({ loaderData, actionData }) {
                         )}
                         {managerView && (
                             <Group gap="xs" hiddenFrom="sm">
-                                {isGameActive && (
-                                    <Button
-                                        variant="light"
-                                        component={Link}
-                                        to={`/events/${eventId}/gameday`}
-                                        leftSection={
-                                            <IconDeviceAnalytics size={16} />
-                                        }
-                                    >
-                                        Scoring
-                                    </Button>
-                                )}
                                 <LineupValidationMenu
                                     validationResults={validationResults}
                                 />
@@ -311,12 +299,25 @@ function Lineup({ loaderData, actionData }) {
                     </Group>
                 </Group>
 
-                <Stack gap={0}>
-                    <Title order={4}>vs. {game?.opponent || "TBD"}</Title>
-                    <Text size="sm" c="dimmed">
-                        {formatForViewerDate(game?.gameDate)}
-                    </Text>
-                </Stack>
+                <Group justify="space-between" align="center" wrap="nowrap">
+                    <Stack gap={0}>
+                        <Title order={4}>vs. {game?.opponent || "TBD"}</Title>
+                        <Text size="sm" c="dimmed">
+                            {formatForViewerDate(game?.gameDate)}
+                        </Text>
+                    </Stack>
+                    {managerView && isGameActive && (
+                        <Button
+                            variant="light"
+                            component={Link}
+                            to={`/events/${eventId}/gameday`}
+                            leftSection={<IconDeviceAnalytics size={16} />}
+                            hiddenFrom="sm"
+                        >
+                            Scoring
+                        </Button>
+                    )}
+                </Group>
             </Stack>
 
             <LineupContainer

--- a/app/routes/lineup/tests/lineup.test.jsx
+++ b/app/routes/lineup/tests/lineup.test.jsx
@@ -20,7 +20,9 @@ jest.mock("@/utils/showNotification", () => ({
     useResponseNotification: jest.fn(),
 }));
 
-jest.mock("@/components/BackButton", () => () => <button>Back</button>);
+jest.mock("@/components/BackButton", () => ({ text }) => (
+    <button>{text || "Event Details"}</button>
+));
 
 jest.mock("@/loaders/games");
 jest.mock("@/actions/lineups");
@@ -248,7 +250,7 @@ describe("Lineup Route", () => {
             );
 
             expect(useResponseNotification).toHaveBeenCalledWith(actionData);
-            expect(screen.getByText("Back")).toBeInTheDocument();
+            expect(screen.getByText("Event Details")).toBeInTheDocument();
             expect(screen.getByTestId("lineup-container")).toBeInTheDocument();
             expect(
                 screen.getByRole("button", { name: /share page/i }),


### PR DESCRIPTION
[![Render.com PR #208 ENV](https://img.shields.io/badge/Render.com%20PR%20%23208%20ENV-blue)](https://softball-manager-react-router-pr-208.onrender.com/)

This PR:
1. Moves the 'Scoring' button to the opponent detail row ('vs. Those Guys') on mobile views.
2. Updates unit tests to assert the correct 'Event Details' text.
3. Keeps the desktop layout unchanged.
