### PR TITLE
fix(spray-chart): force stacked layout inside player details and stats drawers

### DIFF
--- a/app/components/ContactSprayChart/ContactSprayChart.jsx
+++ b/app/components/ContactSprayChart/ContactSprayChart.jsx
@@ -85,6 +85,9 @@ const CATEGORIES_DATA = [
  *     ball was hit (e.g., "left field", "center field"); used for location filters.
  * @param {string} [props.hits[].direction] - Optional alternative to `hitLocation`
  *     describing the hit direction (e.g., "right field line").
+ * @param {"flex"|"stacked"} [props.layout="flex"] - Layout mode for the component.
+ *     "flex" displays the chart and legend side-by-side on desktop.
+ *     "stacked" forces them to be vertical (column) regardless of viewport.
  *
  * @returns {JSX.Element} A card containing the filter controls, field image, and
  * plotted contact points with tooltips for each batted-ball event.
@@ -93,6 +96,7 @@ export default function ContactSprayChart({
     hits = [],
     showBattingSide = true,
     batters = [],
+    layout = "flex",
 }) {
     const [battingSide, setBattingSide] = useState(OVERALL);
     const [categoryFilter, setCategoryFilter] = useState("ALL");
@@ -303,7 +307,7 @@ export default function ContactSprayChart({
                             <Button
                                 variant="subtle"
                                 size="sm"
-                                color="red"
+                                c="red"
                                 onClick={() => {
                                     setCategoryFilter("ALL");
                                     setLocationFilter("ALL");
@@ -319,7 +323,11 @@ export default function ContactSprayChart({
             </Stack>
 
             <Flex
-                direction={{ base: "column", sm: "row" }}
+                direction={
+                    layout === "stacked"
+                        ? "column"
+                        : { base: "column", sm: "row" }
+                }
                 align="stretch"
                 gap="md"
                 mt="md"
@@ -328,7 +336,11 @@ export default function ContactSprayChart({
                     className={styles.mapContainer}
                     radius="lg"
                     p="0px"
-                    flex={{ base: "none", sm: "1 1 300px" }}
+                    flex={
+                        layout === "stacked"
+                            ? "none"
+                            : { base: "none", sm: "1 1 300px" }
+                    }
                     maw={{ base: "100%", sm: 400 }}
                     w="100%"
                 >
@@ -411,7 +423,11 @@ export default function ContactSprayChart({
                 <Card
                     radius="lg"
                     p="sm"
-                    flex={{ base: "none", sm: "1 1 200px" }}
+                    flex={
+                        layout === "stacked"
+                            ? "none"
+                            : { base: "none", sm: "1 1 200px" }
+                    }
                     w="100%"
                 >
                     <Group justify="space-between" mb="xs">
@@ -426,7 +442,11 @@ export default function ContactSprayChart({
                         </Text>
                     </Group>
                     <Flex
-                        direction={{ base: "row", sm: "column" }}
+                        direction={
+                            layout === "stacked"
+                                ? "row"
+                                : { base: "row", sm: "column" }
+                        }
                         wrap="wrap"
                         gap="md"
                     >

--- a/app/components/ContactSprayChart/ContactSprayChart.test.jsx
+++ b/app/components/ContactSprayChart/ContactSprayChart.test.jsx
@@ -93,4 +93,11 @@ describe("ContactSprayChart", () => {
         expect(screen.getByText(/2 hits/i)).toBeInTheDocument();
         expect(screen.getByText(/\.667 AVG/i)).toBeInTheDocument();
     });
+
+    it("renders correctly with layout='stacked' prop", () => {
+        const { container } = render(
+            <ContactSprayChart hits={mockHits} layout="stacked" />,
+        );
+        expect(container.firstChild).toBeInTheDocument();
+    });
 });

--- a/app/routes/team/components/PlayerDetailsDrawer.jsx
+++ b/app/routes/team/components/PlayerDetailsDrawer.jsx
@@ -69,7 +69,7 @@ export default function PlayerDetailsDrawer({
 
                 {showStats && (
                     <Tabs.Panel value="spray" pt="lg">
-                        <ContactSprayChart hits={playerHits} />
+                        <ContactSprayChart hits={playerHits} layout="stacked" />
                     </Tabs.Panel>
                 )}
             </TabsWrapper>

--- a/app/routes/user/components/PlayerStats.jsx
+++ b/app/routes/user/components/PlayerStats.jsx
@@ -258,7 +258,7 @@ export default function PlayerStats({ statsPromise, isDesktop }) {
                             title="Contact Spray Chart"
                             size={isDesktop ? "md" : "xl"}
                         >
-                            <ContactSprayChart hits={logs} />
+                            <ContactSprayChart hits={logs} layout="stacked" />
                         </DrawerContainer>
                     </Stack>
                 );


### PR DESCRIPTION
[![Render.com PR #211 ENV](https://img.shields.io/badge/Render.com%20PR%20%23211%20ENV-blue)](https://softball-manager-react-router-pr-211.onrender.com/)

This PR fixes the layout of the `ContactSprayChart` component inside drawers on the `/team/:teamid` and `/user/:userid` pages on desktop.

### Changes
- Added a `layout` prop to `ContactSprayChart` (default: `"flex"`) to allow forcing a `"stacked"` column layout.
- In `"stacked"` mode:
  - The outer layout stacks vertically (column) regardless of breakpoint.
  - The legend card flexes the legend items horizontally and wraps them (`direction="row"`, `wrap="wrap"`), allowing them to fit compactly within a drawer.
- Passed `layout="stacked"` to `<ContactSprayChart>` in both the team details drawer ([PlayerDetailsDrawer.jsx](file:///Users/josephgordy/Projects/softball-manager-react-router/app/routes/team/components/PlayerDetailsDrawer.jsx)) and the user stats drawer ([PlayerStats.jsx](file:///Users/josephgordy/Projects/softball-manager-react-router/app/routes/user/components/PlayerStats.jsx)).
- Added test coverage in [ContactSprayChart.test.jsx](file:///Users/josephgordy/Projects/softball-manager-react-router/app/components/ContactSprayChart/ContactSprayChart.test.jsx) and verified all unit tests and SSR builds pass successfully.
