### PR TITLE
style: optimize filter select input widths on spray chart

### DIFF
--- a/app/components/ContactSprayChart/ContactSprayChart.jsx
+++ b/app/components/ContactSprayChart/ContactSprayChart.jsx
@@ -272,6 +272,7 @@ export default function ContactSprayChart({
                             <Group className={styles.filterGroup}>
                                 {batters.length > 0 && (
                                     <Select
+                                        className={styles.batterSelect}
                                         label="Batter"
                                         placeholder="All Batters"
                                         data={[
@@ -291,6 +292,7 @@ export default function ContactSprayChart({
                                     />
                                 )}
                                 <Select
+                                    className={styles.resultSelect}
                                     label="Result"
                                     placeholder="All"
                                     data={CATEGORIES_DATA}
@@ -303,6 +305,7 @@ export default function ContactSprayChart({
                                     }}
                                 />
                                 <Select
+                                    className={styles.locationSelect}
                                     label="Location"
                                     placeholder="Anywhere"
                                     data={[
@@ -322,6 +325,7 @@ export default function ContactSprayChart({
                                 />
                                 {games.length > 0 && (
                                     <Select
+                                        className={styles.gameSelect}
                                         label="Game"
                                         placeholder="All Games"
                                         data={[

--- a/app/components/ContactSprayChart/ContactSprayChart.module.css
+++ b/app/components/ContactSprayChart/ContactSprayChart.module.css
@@ -62,11 +62,11 @@
 }
 
 .filterGroup > .resultSelect {
-    width: 115px;
+    width: 95px;
 }
 
 .filterGroup > .locationSelect {
-    width: 135px;
+    width: 115px;
 }
 
 .filterGroup > .gameSelect {

--- a/app/components/ContactSprayChart/ContactSprayChart.module.css
+++ b/app/components/ContactSprayChart/ContactSprayChart.module.css
@@ -55,7 +55,22 @@
 
 .filterGroup > * {
     flex-shrink: 0;
-    min-width: 130px;
+}
+
+.filterGroup > .batterSelect {
+    width: 175px;
+}
+
+.filterGroup > .resultSelect {
+    width: 115px;
+}
+
+.filterGroup > .locationSelect {
+    width: 135px;
+}
+
+.filterGroup > .gameSelect {
+    width: 165px;
 }
 
 @media (min-width: 768px) {
@@ -64,8 +79,7 @@
         flex-wrap: nowrap;
     }
     .filterGroup > * {
-        flex-grow: 1;
+        flex-grow: 0;
         flex-shrink: 1;
-        min-width: 0;
     }
 }


### PR DESCRIPTION
[![Render.com PR #213 ENV](https://img.shields.io/badge/Render.com%20PR%20%23213%20ENV-blue)](https://softball-manager-react-router-pr-213.onrender.com/)

Optimized the widths of the select inputs (specifically Batter, Result, Location, and Game) in the spray chart filters to prevent excessive empty space inside the inputs and clean up the visual hierarchy.

- **Result** Select input reduced to `95px` (fits Ground Out/All Hits/All Outs).
- **Location** Select input reduced to `115px` (fits Center Field/Right Field).
- **Batter** Select input reduced to `175px` (fits player names like David VanGroningen).
- **Game** Select input reduced to `165px`.
- Disabled `flex-grow` on desktop views to keep these inputs content-sized instead of stretching them to full container width.
