### PR TITLE
Add defaultBats preference for switch hitters and update scoring default

### DIFF
--- a/app/actions/tests/users.test.js
+++ b/app/actions/tests/users.test.js
@@ -77,6 +77,7 @@ describe("Users Actions", () => {
                     preferredPositions: ["1B", "OF"],
                     dislikedPositions: ["P", "C"],
                     userId: "unique-id",
+                    defaultBats: null,
                 },
                 [
                     Permission.read(Role.any()),
@@ -116,6 +117,7 @@ describe("Users Actions", () => {
                     preferredPositions: ["P", "C"],
                     dislikedPositions: ["OF"], // C was removed
                     userId: "user123",
+                    defaultBats: null,
                 },
                 [
                     Permission.read(Role.any()),

--- a/app/actions/tests/users.test.js
+++ b/app/actions/tests/users.test.js
@@ -167,6 +167,32 @@ describe("Users Actions", () => {
             expect(result.success).toBe(false);
             expect(result.status).toBe(400);
         });
+
+        it("should set defaultBats appropriately when creating a player", async () => {
+            const mockValues = {
+                firstName: "John",
+                lastName: "Doe",
+                bats: "Switch",
+                defaultBats: "left",
+            };
+            createDocument.mockResolvedValue({ $id: "user1" });
+            await createPlayer({
+                values: mockValues,
+                teamId: "team1",
+                userId: null,
+                client: mockClient,
+            });
+            expect(createDocument).toHaveBeenCalledWith(
+                "users",
+                "unique-id",
+                expect.objectContaining({
+                    bats: "Switch",
+                    defaultBats: "left",
+                }),
+                expect.any(Array),
+                expect.any(Object),
+            );
+        });
     });
 
     describe("updateUser", () => {
@@ -385,6 +411,44 @@ describe("Users Actions", () => {
 
             expect(result.success).toBe(false);
             expect(result.status).toBe(400);
+        });
+
+        it("should handle defaultBats appropriately when updating bats to Switch vs other", async () => {
+            const userId = "user1";
+            readDocument.mockResolvedValue({ $id: userId, bats: "Right" });
+            updateDocument.mockResolvedValue({ $id: userId });
+
+            await updateUser({
+                values: { bats: "Switch", defaultBats: "left" },
+                userId,
+                client: mockClient,
+            });
+
+            expect(updateDocument).toHaveBeenCalledWith(
+                "users",
+                userId,
+                expect.objectContaining({
+                    bats: "Switch",
+                    defaultBats: "left",
+                }),
+                mockClient,
+            );
+
+            await updateUser({
+                values: { bats: "Right" },
+                userId,
+                client: mockClient,
+            });
+
+            expect(updateDocument).toHaveBeenCalledWith(
+                "users",
+                userId,
+                expect.objectContaining({
+                    bats: "Right",
+                    defaultBats: null,
+                }),
+                mockClient,
+            );
         });
     });
 

--- a/app/actions/users.js
+++ b/app/actions/users.js
@@ -50,6 +50,9 @@ export async function createPlayer({ values, teamId, userId, client }) {
               ]
             : [];
 
+        const defaultBats =
+            values.bats === "Switch" ? values.defaultBats || "right" : null;
+
         const player = await createDocument(
             "users",
             _userId,
@@ -58,6 +61,7 @@ export async function createPlayer({ values, teamId, userId, client }) {
                 preferredPositions,
                 dislikedPositions,
                 userId: _userId,
+                defaultBats,
             },
             docPermissions,
             client,
@@ -82,6 +86,14 @@ export async function updateUser({ values, userId, client }) {
     if (dataToUpdate.dislikedPositions) {
         dataToUpdate.dislikedPositions =
             dataToUpdate.dislikedPositions.split(",");
+    }
+
+    if (dataToUpdate.bats) {
+        if (dataToUpdate.bats === "Switch") {
+            dataToUpdate.defaultBats = dataToUpdate.defaultBats || "right";
+        } else {
+            dataToUpdate.defaultBats = null;
+        }
     }
 
     try {

--- a/app/forms/AddPlayer.jsx
+++ b/app/forms/AddPlayer.jsx
@@ -56,6 +56,7 @@ export default function AddPlayer({
 
     const [preferred, setPreferred] = useState(initialPreferred);
     const [disliked, setDisliked] = useState(initialDisliked);
+    const [bats, setBats] = useState(defaults.bats || "Right");
 
     return (
         <FormWrapper
@@ -134,7 +135,8 @@ export default function AddPlayer({
                         name="bats"
                         label="Bats"
                         description="Select whether you bat left, right, or switch"
-                        defaultValue={defaults.bats || "Right"}
+                        value={bats}
+                        onChange={setBats}
                         size="md"
                     >
                         <Group mt="xs">
@@ -143,6 +145,22 @@ export default function AddPlayer({
                             <Radio value="Switch" label="Switch" />
                         </Group>
                     </Radio.Group>
+                    {bats === "Switch" && (
+                        <Radio.Group
+                            mb="md"
+                            className={classes.inputs}
+                            name="defaultBats"
+                            label="Default Batting Side"
+                            description="Select which side you default to as a switch hitter"
+                            defaultValue={defaults.defaultBats || "right"}
+                            size="md"
+                        >
+                            <Group mt="xs">
+                                <Radio value="left" label="Left" />
+                                <Radio value="right" label="Right" />
+                            </Group>
+                        </Radio.Group>
+                    )}
                 </>
             )}
 

--- a/app/forms/tests/AddPlayer.test.jsx
+++ b/app/forms/tests/AddPlayer.test.jsx
@@ -227,4 +227,26 @@ describe("AddPlayer", () => {
         );
         expect(preferredOptions).not.toContain("Catcher");
     });
+
+    it("renders defaultBats fields conditionally based on bats value", () => {
+        const { rerender } = render(
+            <AddPlayer
+                inputsToDisplay={["throws-bats"]}
+                defaults={{ bats: "Right" }}
+            />,
+        );
+        expect(
+            screen.queryByLabelText(/Default Batting Side/i),
+        ).not.toBeInTheDocument();
+
+        rerender(
+            <AddPlayer
+                inputsToDisplay={["throws-bats"]}
+                defaults={{ bats: "Switch" }}
+            />,
+        );
+        expect(
+            screen.getByLabelText(/Default Batting Side/i),
+        ).toBeInTheDocument();
+    });
 });

--- a/app/forms/tests/AddPlayer.test.jsx
+++ b/app/forms/tests/AddPlayer.test.jsx
@@ -228,8 +228,8 @@ describe("AddPlayer", () => {
         expect(preferredOptions).not.toContain("Catcher");
     });
 
-    it("renders defaultBats fields conditionally based on bats value", () => {
-        const { rerender } = render(
+    it("does not render defaultBats fields when bats is Right", () => {
+        render(
             <AddPlayer
                 inputsToDisplay={["throws-bats"]}
                 defaults={{ bats: "Right" }}
@@ -238,8 +238,10 @@ describe("AddPlayer", () => {
         expect(
             screen.queryByLabelText(/Default Batting Side/i),
         ).not.toBeInTheDocument();
+    });
 
-        rerender(
+    it("renders defaultBats fields when bats is Switch", () => {
+        render(
             <AddPlayer
                 inputsToDisplay={["throws-bats"]}
                 defaults={{ bats: "Switch" }}

--- a/app/routes/gameday/components/DesktopPlayActionDrawer.jsx
+++ b/app/routes/gameday/components/DesktopPlayActionDrawer.jsx
@@ -43,7 +43,7 @@ export default function DesktopPlayActionDrawer({
 }) {
     const isSwitchHitter = currentBatter?.bats?.toLowerCase() === "switch";
     const bats = isSwitchHitter
-        ? "left"
+        ? currentBatter?.defaultBats || "right"
         : currentBatter?.bats?.toLowerCase() || "right";
 
     const [selectedPosition, setSelectedPosition] = useState(null);

--- a/app/routes/gameday/components/MobilePlayActionDrawer.jsx
+++ b/app/routes/gameday/components/MobilePlayActionDrawer.jsx
@@ -43,7 +43,7 @@ export default function MobilePlayActionDrawer({
 }) {
     const isSwitchHitter = currentBatter?.bats?.toLowerCase() === "switch";
     const bats = isSwitchHitter
-        ? "left"
+        ? currentBatter?.defaultBats || "right"
         : currentBatter?.bats?.toLowerCase() || "right";
 
     const [selectedPosition, setSelectedPosition] = useState(null);

--- a/app/routes/gameday/components/tests/DesktopPlayActionDrawer.test.jsx
+++ b/app/routes/gameday/components/tests/DesktopPlayActionDrawer.test.jsx
@@ -310,4 +310,32 @@ describe("DesktopPlayActionDrawer", () => {
             configurable: true,
         });
     });
+
+    it("defaults battingSide based on defaultBats for switch hitters", () => {
+        const switchHitterLeft = {
+            ...defaultProps.currentBatter,
+            bats: "Switch",
+            defaultBats: "left",
+        };
+        const { rerender } = render(
+            <DesktopPlayActionDrawer
+                {...defaultProps}
+                currentBatter={switchHitterLeft}
+            />,
+        );
+        expect(screen.getByLabelText("Left")).toBeChecked();
+
+        const switchHitterRight = {
+            ...defaultProps.currentBatter,
+            bats: "Switch",
+            defaultBats: "right",
+        };
+        rerender(
+            <DesktopPlayActionDrawer
+                {...defaultProps}
+                currentBatter={switchHitterRight}
+            />,
+        );
+        expect(screen.getByLabelText("Right")).toBeChecked();
+    });
 });

--- a/app/routes/gameday/components/tests/DesktopPlayActionDrawer.test.jsx
+++ b/app/routes/gameday/components/tests/DesktopPlayActionDrawer.test.jsx
@@ -311,26 +311,28 @@ describe("DesktopPlayActionDrawer", () => {
         });
     });
 
-    it("defaults battingSide based on defaultBats for switch hitters", () => {
+    it("defaults battingSide based on defaultBats for switch hitters (left)", () => {
         const switchHitterLeft = {
             ...defaultProps.currentBatter,
             bats: "Switch",
             defaultBats: "left",
         };
-        const { rerender } = render(
+        render(
             <DesktopPlayActionDrawer
                 {...defaultProps}
                 currentBatter={switchHitterLeft}
             />,
         );
         expect(screen.getByLabelText("Left")).toBeChecked();
+    });
 
+    it("defaults battingSide based on defaultBats for switch hitters (right)", () => {
         const switchHitterRight = {
             ...defaultProps.currentBatter,
             bats: "Switch",
             defaultBats: "right",
         };
-        rerender(
+        render(
             <DesktopPlayActionDrawer
                 {...defaultProps}
                 currentBatter={switchHitterRight}

--- a/app/routes/gameday/components/tests/MobilePlayActionDrawer.test.jsx
+++ b/app/routes/gameday/components/tests/MobilePlayActionDrawer.test.jsx
@@ -214,4 +214,32 @@ describe("MobilePlayActionDrawer", () => {
         const rfBtn = document.querySelector(".tour-field-position-rf");
         expect(rfBtn).toBeInTheDocument();
     });
+
+    it("defaults battingSide based on defaultBats for switch hitters", () => {
+        const switchHitterLeft = {
+            ...defaultProps.currentBatter,
+            bats: "Switch",
+            defaultBats: "left",
+        };
+        const { rerender } = render(
+            <MobilePlayActionDrawer
+                {...defaultProps}
+                currentBatter={switchHitterLeft}
+            />,
+        );
+        expect(screen.getByLabelText("Left")).toBeChecked();
+
+        const switchHitterRight = {
+            ...defaultProps.currentBatter,
+            bats: "Switch",
+            defaultBats: "right",
+        };
+        rerender(
+            <MobilePlayActionDrawer
+                {...defaultProps}
+                currentBatter={switchHitterRight}
+            />,
+        );
+        expect(screen.getByLabelText("Right")).toBeChecked();
+    });
 });

--- a/app/routes/gameday/components/tests/MobilePlayActionDrawer.test.jsx
+++ b/app/routes/gameday/components/tests/MobilePlayActionDrawer.test.jsx
@@ -215,26 +215,28 @@ describe("MobilePlayActionDrawer", () => {
         expect(rfBtn).toBeInTheDocument();
     });
 
-    it("defaults battingSide based on defaultBats for switch hitters", () => {
+    it("defaults battingSide based on defaultBats for switch hitters (left)", () => {
         const switchHitterLeft = {
             ...defaultProps.currentBatter,
             bats: "Switch",
             defaultBats: "left",
         };
-        const { rerender } = render(
+        render(
             <MobilePlayActionDrawer
                 {...defaultProps}
                 currentBatter={switchHitterLeft}
             />,
         );
         expect(screen.getByLabelText("Left")).toBeChecked();
+    });
 
+    it("defaults battingSide based on defaultBats for switch hitters (right)", () => {
         const switchHitterRight = {
             ...defaultProps.currentBatter,
             bats: "Switch",
             defaultBats: "right",
         };
-        rerender(
+        render(
             <MobilePlayActionDrawer
                 {...defaultProps}
                 currentBatter={switchHitterRight}


### PR DESCRIPTION
[![Render.com PR #214 ENV](https://img.shields.io/badge/Render.com%20PR%20%23214%20ENV-blue)](https://softball-manager-react-router-pr-214.onrender.com/)

This PR introduces the `defaultBats` preference for switch hitters and updates the scoring logic to utilize it.

### Changes:
- **Database**: Added the `defaultBats` enum column to the `users` table defaulting to `"right"`.
- **Dan Soltis**: Updated Dan's profile in the database to use `defaultBats: "right"`.
- **Form / UI**: Added a conditional `defaultBats` selection in the `AddPlayer` form when `"Switch"` is selected as the batting side.
- **Actions**: Adjusted `createPlayer` and `updateUser` actions to process, default, or clear `defaultBats`.
- **Scoring**: Refactored the desktop and mobile play action drawers to initialize the active batting side using the batter's `defaultBats` (falling back to `"right"`) instead of hardcoding a `"left"` default.
- **Tests**: Added coverage for actions, forms, and scoring drawers.
