### PR TITLE
style: make all TabsWrapper controls responsively compact on desktop

### DIFF
--- a/app/components/TabsWrapper/TabsWrapper.jsx
+++ b/app/components/TabsWrapper/TabsWrapper.jsx
@@ -38,6 +38,7 @@ export default function TabsWrapper({
     children,
     mt = "xl",
     align = "center",
+    size = "sm",
 }) {
     const [rootRef, setRootRef] = useState(null);
     const [uncontrolledValue, setUncontrolledValue] = useState(
@@ -95,7 +96,7 @@ export default function TabsWrapper({
                     key: child.props.value,
                     ref: setControlRef(child.props.value),
                     className:
-                        `${classes.tab} ${isActive ? classes.tabActive : ""} ${child.props.className || ""}`.trim(),
+                        `${classes.tab} ${size === "xs" ? classes.tabXs : ""} ${isActive ? classes.tabActive : ""} ${child.props.className || ""}`.trim(),
                     disabled: child.props.disabled,
                     style: {
                         ...child.props.style,
@@ -115,7 +116,7 @@ export default function TabsWrapper({
             <div className={classes.scrollWrapper}>
                 <Tabs.List
                     ref={setRootRef}
-                    className={classes.list}
+                    className={`${classes.list} ${size === "xs" ? classes.listXs : ""}`.trim()}
                     style={align === "left" ? { margin: "0" } : undefined}
                 >
                     {tabs}

--- a/app/components/TabsWrapper/TabsWrapper.module.css
+++ b/app/components/TabsWrapper/TabsWrapper.module.css
@@ -56,3 +56,32 @@
     bottom: 0;
     border-radius: var(--mantine-radius-xl);
 }
+
+.listXs {
+    padding: 3px;
+    gap: 2px;
+}
+
+.tabXs {
+    padding: 4px 10px;
+    font-size: 11px;
+    gap: 4px;
+}
+
+@media (min-width: 48em) {
+    .list {
+        padding: 3px;
+        gap: 2px;
+    }
+
+    .tab {
+        padding: 4px 10px;
+        font-size: 11px;
+        gap: 4px;
+    }
+
+    .tab svg {
+        width: 14px !important;
+        height: 14px !important;
+    }
+}

--- a/app/components/TabsWrapper/TabsWrapper.test.jsx
+++ b/app/components/TabsWrapper/TabsWrapper.test.jsx
@@ -101,4 +101,19 @@ describe("TabsWrapper", () => {
         const tabButton = screen.getByText("Tab 1").closest("button");
         expect(tabButton).toHaveClass("custom-test-class");
     });
+
+    it("applies xs classes when size='xs' is passed", () => {
+        render(
+            <TabsWrapper defaultValue="tab1" size="xs">
+                <Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
+                <Tabs.Panel value="tab1">Content 1</Tabs.Panel>
+            </TabsWrapper>,
+        );
+
+        const tabList = screen.getByRole("tablist");
+        const tabButton = screen.getByText("Tab 1").closest("button");
+
+        expect(tabList).toHaveClass("listXs");
+        expect(tabButton).toHaveClass("tabXs");
+    });
 });


### PR DESCRIPTION
[![Render.com PR #215 ENV](https://img.shields.io/badge/Render.com%20PR%20%23215%20ENV-blue)](https://softball-manager-react-router-pr-215.onrender.com/)

This PR updates the CSS for the `TabsWrapper` component to responsively scale down to a compact, space-saving size (`xs` equivalent layout) on desktop screens (screen widths >= `48em` / `768px`).

Key updates:
- Added a `@media (min-width: 48em)` block to `TabsWrapper.module.css` to reduce tab/list margins, padding, spacing, and font sizes.
- Scales inner SVG/tabler icons automatically to `14px` on desktop viewports.
- Tested and verified locally via the global test suite.
