### PR TITLE
feat: Add runs per game on player profile stats

### DIFF
--- a/app/actions/gameLogs.js
+++ b/app/actions/gameLogs.js
@@ -141,6 +141,10 @@ export const logGameEvent = async ({
             hitY: normalizeOptionalField(hitY, parseFloat),
             hitLocation: normalizeOptionalField(hitLocation),
             battingSide: normalizeOptionalField(battingSide),
+            scored:
+                safeBaseState.scored && Array.isArray(safeBaseState.scored)
+                    ? safeBaseState.scored
+                    : [],
         };
 
         const isHomeTeam =
@@ -408,6 +412,10 @@ export const updateGameEvent = async ({
                     runnerResults: parsedRunnerResults,
                 }),
             }),
+            scored:
+                parsedBase.scored && Array.isArray(parsedBase.scored)
+                    ? parsedBase.scored
+                    : [],
         };
         // Remove runnerResults from payload as it's not a root attribute
         delete logPayload.runnerResults;

--- a/app/actions/tests/gameLogs.test.js
+++ b/app/actions/tests/gameLogs.test.js
@@ -50,7 +50,12 @@ describe("gameLogs actions", () => {
                 rbi: 1,
                 outsOnPlay: 0,
                 description: "John Doe singles",
-                baseState: { first: true, second: false, third: false },
+                baseState: {
+                    first: true,
+                    second: false,
+                    third: false,
+                    scored: ["player789"],
+                },
             };
 
             const mockTransaction = { $id: "txn-123" };
@@ -83,6 +88,7 @@ describe("gameLogs actions", () => {
                             rbi: 1,
                             outsOnPlay: 0,
                             description: "John Doe singles",
+                            scored: ["player789"],
                             baseState: JSON.stringify(mockPayload.baseState),
                         }),
                         permissions: expect.arrayContaining([
@@ -113,7 +119,7 @@ describe("gameLogs actions", () => {
                 rbi: 0,
                 outsOnPlay: 1,
                 description: "K",
-                baseState: {},
+                baseState: { scored: [] },
             };
 
             createDocument.mockResolvedValue({ $id: "log790", ...mockPayload });
@@ -134,6 +140,7 @@ describe("gameLogs actions", () => {
                 expect.objectContaining({
                     gameId: "game123",
                     playerId: "player456",
+                    scored: [],
                 }),
                 expect.arrayContaining([
                     'read("any")',
@@ -618,7 +625,7 @@ describe("gameLogs actions", () => {
                 first: null,
                 second: "player1",
                 third: null,
-                scored: [],
+                scored: ["player2"],
             }),
             runnerResults: JSON.stringify({
                 batter: "second",
@@ -651,6 +658,7 @@ describe("gameLogs actions", () => {
                 expect.objectContaining({
                     hitX: 75.63,
                     hitY: 40.02,
+                    scored: ["player2"],
                 }),
                 mockClient,
             );
@@ -679,6 +687,7 @@ describe("gameLogs actions", () => {
                 expect.objectContaining({
                     hitX: 75.63,
                     hitY: 40.02,
+                    scored: ["player2"],
                 }),
                 mockClient,
             );
@@ -706,6 +715,7 @@ describe("gameLogs actions", () => {
                 "log1",
                 expect.objectContaining({
                     baseState: expect.stringContaining("runnerResults"),
+                    scored: ["player2"],
                 }),
                 mockClient,
             );

--- a/app/loaders/tests/users.test.js
+++ b/app/loaders/tests/users.test.js
@@ -22,6 +22,8 @@ jest.mock("node-appwrite", () => ({
         select: jest.fn(
             (attrs) => `select([${attrs.map((a) => `"${a}"`).join(", ")}])`,
         ),
+        or: jest.fn((queries) => `or([${queries.join(",")}])`),
+        contains: jest.fn((attr, value) => `contains("${attr}", "${value}")`),
     },
 }));
 
@@ -69,7 +71,9 @@ describe("Users Loader", () => {
             expect(listDocuments).toHaveBeenCalledWith(
                 "game_logs",
                 expect.arrayContaining([
-                    expect.stringContaining('equal("playerId", "user1")'),
+                    expect.stringContaining(
+                        'or([equal("playerId", "user1"),contains("scored", "user1")])',
+                    ),
                     expect.stringContaining('orderDesc("$createdAt")'),
                     expect.stringContaining("limit(500)"),
                 ]),
@@ -104,6 +108,7 @@ describe("Users Loader", () => {
                 mockClient,
             );
 
+            expect(result.userId).toEqual("user1");
             expect(result.logs).toEqual(mockLogs);
             expect(result.games).toEqual(mockGames);
             expect(result.teams).toEqual(mockTeams);
@@ -145,7 +150,12 @@ describe("Users Loader", () => {
             });
 
             expect(listDocuments).toHaveBeenCalledTimes(1);
-            expect(result).toEqual({ logs: [], games: [], teams: [] });
+            expect(result).toEqual({
+                userId: "user1",
+                logs: [],
+                games: [],
+                teams: [],
+            });
         });
     });
 

--- a/app/loaders/users.js
+++ b/app/loaders/users.js
@@ -52,7 +52,10 @@ export async function getStatsByUserId({ userId, client }) {
         const logsResponse = await listDocuments(
             "game_logs",
             [
-                Query.equal("playerId", userId),
+                Query.or([
+                    Query.equal("playerId", userId),
+                    Query.contains("scored", userId),
+                ]),
                 Query.orderDesc("$createdAt"),
                 Query.limit(500),
             ],
@@ -62,7 +65,7 @@ export async function getStatsByUserId({ userId, client }) {
         const logs = logsResponse.rows;
 
         if (logs.length === 0) {
-            return { logs: [], games: [], teams: [] };
+            return { userId, logs: [], games: [], teams: [] };
         }
 
         // 2. Extract unique game IDs
@@ -111,12 +114,13 @@ export async function getStatsByUserId({ userId, client }) {
         }
 
         return {
+            userId,
             logs,
             games,
             teams,
         };
     } catch (err) {
         console.error("[getStatsByUserId] Error:", err);
-        return { logs: [], games: [], teams: [] };
+        return { userId, logs: [], games: [], teams: [] };
     }
 }

--- a/app/routes/user/components/PlayerStats.jsx
+++ b/app/routes/user/components/PlayerStats.jsx
@@ -84,7 +84,12 @@ export default function PlayerStats({ statsPromise, isDesktop }) {
                     );
                 }
 
-                const { logs = [], games = [], teams = [] } = data || {};
+                const {
+                    userId,
+                    logs = [],
+                    games = [],
+                    teams = [],
+                } = data || {};
 
                 if (!logs.length) {
                     return (
@@ -119,16 +124,16 @@ export default function PlayerStats({ statsPromise, isDesktop }) {
                     return new Date(gameB.gameDate) - new Date(gameA.gameDate);
                 });
 
-                // Take up to the last 10 games
-                const last10GameIds = sortedGameIds.slice(0, 10);
+                // Take up to the last 20 games
+                const recentGameIds = sortedGameIds.slice(0, 20);
 
-                const overallStats = calculatePlayerStats(logs);
+                const overallStats = calculatePlayerStats(logs, userId);
 
                 return (
                     <Stack gap="md" mt="md">
                         <Paper withBorder p="md" radius="md">
                             <Text fw={700} mb="xs">
-                                Last {last10GameIds.length} Games
+                                Last {recentGameIds.length} Games
                             </Text>
                             <Group my="md" grow>
                                 <Stack gap={0} align="center">
@@ -189,6 +194,7 @@ export default function PlayerStats({ statsPromise, isDesktop }) {
                                     <Table.Tr>
                                         <Table.Th>AB</Table.Th>
                                         <Table.Th>H</Table.Th>
+                                        <Table.Th>R</Table.Th>
                                         <Table.Th>RBI</Table.Th>
                                         <Table.Th>2B</Table.Th>
                                         <Table.Th>3B</Table.Th>
@@ -200,6 +206,7 @@ export default function PlayerStats({ statsPromise, isDesktop }) {
                                     <Table.Tr>
                                         <Table.Td>{overallStats.ab}</Table.Td>
                                         <Table.Td>{overallStats.hits}</Table.Td>
+                                        <Table.Td>{overallStats.runs}</Table.Td>
                                         <Table.Td>{overallStats.rbi}</Table.Td>
                                         <Table.Td>
                                             {overallStats.doubles}
@@ -227,7 +234,7 @@ export default function PlayerStats({ statsPromise, isDesktop }) {
                             </Button>
                         </Paper>
 
-                        {last10GameIds.map((gameId) => {
+                        {recentGameIds.map((gameId) => {
                             const game = gamesMap[gameId];
                             const gameLogs = logsByGame[gameId];
 
@@ -238,6 +245,7 @@ export default function PlayerStats({ statsPromise, isDesktop }) {
                                     key={gameId}
                                     game={game}
                                     logs={gameLogs}
+                                    userId={userId}
                                     onClick={() =>
                                         handleGameClick(game, gameLogs)
                                     }
@@ -250,6 +258,7 @@ export default function PlayerStats({ statsPromise, isDesktop }) {
                             onClose={close}
                             game={selectedGame?.game}
                             logs={selectedGame?.logs}
+                            userId={userId}
                         />
 
                         <DrawerContainer

--- a/app/routes/user/components/stats/GameStatsCard.jsx
+++ b/app/routes/user/components/stats/GameStatsCard.jsx
@@ -3,8 +3,9 @@ import { DateTime } from "luxon";
 
 import { calculatePlayerStats } from "@/utils/stats";
 
-export default function GameStatsCard({ game, logs, onClick }) {
-    const stats = calculatePlayerStats(logs);
+export default function GameStatsCard({ game, logs = [], onClick, userId }) {
+    // 1. Calculate base stats for the user
+    const stats = calculatePlayerStats(logs, userId);
     const date = DateTime.fromISO(game.gameDate).toLocaleString(
         DateTime.DATE_MED,
     );
@@ -43,16 +44,28 @@ export default function GameStatsCard({ game, logs, onClick }) {
                         )}
                     </Group>
 
-                    {stats.rbi > 0 && (
-                        <Badge
-                            variant="filled"
-                            color="blue"
-                            size="md"
-                            radius="xl"
-                        >
-                            {stats.rbi} RBI
-                        </Badge>
-                    )}
+                    <Group gap="xs">
+                        {stats.runs > 0 && (
+                            <Badge
+                                variant="light"
+                                color="blue"
+                                size="md"
+                                radius="xl"
+                            >
+                                {stats.runs} {stats.runs === 1 ? "Run" : "Runs"}
+                            </Badge>
+                        )}
+                        {stats.rbi > 0 && (
+                            <Badge
+                                variant="filled"
+                                color="blue"
+                                size="md"
+                                radius="xl"
+                            >
+                                {stats.rbi} RBI
+                            </Badge>
+                        )}
+                    </Group>
                 </Group>
             </Card>
         </UnstyledButton>

--- a/app/routes/user/components/stats/StatsDetailDrawer.jsx
+++ b/app/routes/user/components/stats/StatsDetailDrawer.jsx
@@ -5,12 +5,18 @@ import { DateTime } from "luxon";
 import DrawerContainer from "@/components/DrawerContainer";
 import { calculatePlayerStats } from "@/utils/stats";
 
-export default function StatsDetailDrawer({ opened, onClose, game, logs }) {
+export default function StatsDetailDrawer({
+    opened,
+    onClose,
+    game,
+    logs,
+    userId,
+}) {
     const { isDesktop } = useOutletContext();
 
     if (!game) return null;
 
-    const stats = calculatePlayerStats(logs || []);
+    const stats = calculatePlayerStats(logs || [], userId);
     const { details } = stats;
 
     const date = DateTime.fromISO(game.gameDate).toLocaleString(
@@ -20,6 +26,7 @@ export default function StatsDetailDrawer({ opened, onClose, game, logs }) {
     const rows = [
         { label: "At Bats", value: stats.ab },
         { label: "Hits", value: stats.hits },
+        { label: "Runs", value: stats.runs },
         { label: "Singles", value: details["1B"] },
         { label: "Doubles", value: details["2B"] },
         { label: "Triples", value: details["3B"] },

--- a/app/routes/user/components/stats/tests/GameStatsCard.test.jsx
+++ b/app/routes/user/components/stats/tests/GameStatsCard.test.jsx
@@ -13,14 +13,15 @@ const mockGame = {
 };
 
 const mockLogs = [
-    { eventType: UI_KEYS.SINGLE, rbi: 1 },
-    { eventType: UI_KEYS.DOUBLE, rbi: 2 },
-    { eventType: UI_KEYS.FLY_OUT, rbi: 0 },
+    { playerId: "player1", eventType: UI_KEYS.SINGLE, rbi: 1 },
+    { playerId: "player1", eventType: UI_KEYS.DOUBLE, rbi: 2 },
+    { playerId: "player1", eventType: UI_KEYS.FLY_OUT, rbi: 0 },
 ];
 
 const defaultProps = {
     game: mockGame,
     logs: mockLogs,
+    userId: "player1",
 };
 
 describe("GameStatsCard Component", () => {
@@ -51,7 +52,10 @@ describe("GameStatsCard Component", () => {
     });
 
     it("handles multiple extra base hits in summary text", () => {
-        const extraLogs = [{ eventType: "2B" }, { eventType: "HR" }];
+        const extraLogs = [
+            { playerId: "player1", eventType: "2B" },
+            { playerId: "player1", eventType: "HR" },
+        ];
         render(
             <GameStatsCard
                 {...defaultProps}
@@ -61,5 +65,25 @@ describe("GameStatsCard Component", () => {
         );
 
         expect(screen.getByText("[2B, HR]")).toBeInTheDocument();
+    });
+
+    it("renders runs badge when runs > 0", () => {
+        const logsWithRuns = [
+            { playerId: "player1", eventType: "single", rbi: 1 },
+            {
+                playerId: "player1",
+                eventType: "single",
+                rbi: 0,
+                scored: ["player1"],
+            },
+        ];
+        render(
+            <GameStatsCard
+                {...defaultProps}
+                logs={logsWithRuns}
+                onClick={() => {}}
+            />,
+        );
+        expect(screen.getByText("1 Run")).toBeInTheDocument();
     });
 });

--- a/app/routes/user/components/stats/tests/StatsDetailDrawer.test.jsx
+++ b/app/routes/user/components/stats/tests/StatsDetailDrawer.test.jsx
@@ -29,9 +29,9 @@ describe("StatsDetailDrawer Component", () => {
     };
 
     const mockLogs = [
-        { eventType: UI_KEYS.SINGLE, rbi: 1 },
-        { eventType: UI_KEYS.HOMERUN, rbi: 4 },
-        { eventType: UI_KEYS.FLY_OUT, rbi: 0 },
+        { playerId: "player1", eventType: UI_KEYS.SINGLE, rbi: 1 },
+        { playerId: "player1", eventType: UI_KEYS.HOMERUN, rbi: 4 },
+        { playerId: "player1", eventType: UI_KEYS.FLY_OUT, rbi: 0 },
     ];
 
     it("renders nothing if game is missing", () => {
@@ -41,6 +41,7 @@ describe("StatsDetailDrawer Component", () => {
                 onClose={() => {}}
                 game={null}
                 logs={[]}
+                userId="player1"
             />,
         );
         expect(screen.queryByTestId("drawer")).not.toBeInTheDocument();
@@ -53,6 +54,7 @@ describe("StatsDetailDrawer Component", () => {
                 onClose={() => {}}
                 game={mockGame}
                 logs={mockLogs}
+                userId="player1"
             />,
         );
         expect(screen.queryByTestId("drawer")).not.toBeInTheDocument();
@@ -65,6 +67,7 @@ describe("StatsDetailDrawer Component", () => {
                 onClose={() => {}}
                 game={mockGame}
                 logs={mockLogs}
+                userId="player1"
             />,
         );
 
@@ -73,6 +76,7 @@ describe("StatsDetailDrawer Component", () => {
 
         // Check table rows
         expect(screen.getByText("At Bats")).toBeInTheDocument();
+        expect(screen.getByText("Runs")).toBeInTheDocument();
         expect(screen.getByText("Home Runs")).toBeInTheDocument();
 
         // Check RBI - it should sum to 5 (1 + 4)
@@ -88,6 +92,7 @@ describe("StatsDetailDrawer Component", () => {
                 onClose={() => {}}
                 game={mockGame}
                 logs={mockLogs}
+                userId="player1"
             />,
         );
 
@@ -104,6 +109,7 @@ describe("StatsDetailDrawer Component", () => {
                 onClose={() => {}}
                 game={mockGame}
                 logs={mockLogs}
+                userId="player1"
             />,
         );
 

--- a/app/routes/user/components/tests/PlayerStats.test.jsx
+++ b/app/routes/user/components/tests/PlayerStats.test.jsx
@@ -39,9 +39,11 @@ describe("PlayerStats Component", () => {
     };
 
     const mockStatsData = {
+        userId: "player1",
         logs: [
             {
                 gameId: "g1",
+                playerId: "player1",
                 eventType: UI_KEYS.SINGLE,
                 rbi: 1,
                 angle: 90,
@@ -49,6 +51,7 @@ describe("PlayerStats Component", () => {
             },
             {
                 gameId: "g1",
+                playerId: "player1",
                 eventType: UI_KEYS.HOMERUN,
                 rbi: 4,
                 angle: 45,

--- a/app/utils/stats.js
+++ b/app/utils/stats.js
@@ -265,10 +265,11 @@ export const calculateTeamTotals = (statsArray) => {
  * @param {Array} logs - Array of game log objects for a single player
  * @returns {Object} Stats object
  */
-export const calculatePlayerStats = (logs) => {
+export const calculatePlayerStats = (logs, userId) => {
     let hits = 0;
     let ab = 0; // At Bats
     let rbi = 0;
+    let runs = 0;
     let doubles = 0;
     let triples = 0;
     let homeruns = 0;
@@ -298,11 +299,33 @@ export const calculatePlayerStats = (logs) => {
         )
             return;
 
-        const eventType = log.eventType;
-        const logRbi = log.rbi || 0;
+        const isUsersAtBat = log.playerId === userId;
 
-        rbi += logRbi;
-        details.RBI += logRbi;
+        // Count RBI only if it's the user's at-bat
+        if (isUsersAtBat) {
+            const logRbi = log.rbi || 0;
+            rbi += logRbi;
+            details.RBI += logRbi;
+        }
+
+        // Parse baseState to check for runs
+        let baseState = {};
+        try {
+            baseState =
+                typeof log.baseState === "string"
+                    ? JSON.parse(log.baseState)
+                    : log.baseState || {};
+        } catch (_e) {}
+
+        const scoredList = log.scored || baseState.scored || [];
+        if (Array.isArray(scoredList) && scoredList.includes(userId)) {
+            runs++;
+        }
+
+        // Only count hitting stats (AB, Hits, etc) if this log belongs to the user's at-bat
+        if (!isUsersAtBat) return;
+
+        const eventType = log.eventType;
 
         // Standardize event type
         let type = eventType;
@@ -387,6 +410,7 @@ export const calculatePlayerStats = (logs) => {
         hits,
         ab,
         rbi,
+        runs,
         doubles,
         triples,
         homeruns,

--- a/app/utils/tests/stats.test.js
+++ b/app/utils/tests/stats.test.js
@@ -751,7 +751,7 @@ describe("calculateTeamTotals", () => {
 
 describe("calculatePlayerStats", () => {
     it("should initialize with zero stats for empty logs", () => {
-        const stats = calculatePlayerStats([]);
+        const stats = calculatePlayerStats([], "player1");
         expect(stats.hits).toBe(0);
         expect(stats.ab).toBe(0);
         expect(stats.rbi).toBe(0);
@@ -766,7 +766,8 @@ describe("calculatePlayerStats", () => {
             { eventType: "triple", rbi: 2 },
         ];
 
-        const stats = calculatePlayerStats(logs);
+        const mappedLogs = logs.map((l) => ({ ...l, playerId: "player1" }));
+        const stats = calculatePlayerStats(mappedLogs, "player1");
 
         expect(stats.ab).toBe(4);
         expect(stats.hits).toBe(3); // 1B, 2B, 3B
@@ -789,7 +790,8 @@ describe("calculatePlayerStats", () => {
         // AVG: 1 / 2 = .500
         // OBP: (1 + 1) / (2 + 1 + 1) = 2 / 4 = .500
 
-        const stats = calculatePlayerStats(logs);
+        const mappedLogs = logs.map((l) => ({ ...l, playerId: "player1" }));
+        const stats = calculatePlayerStats(mappedLogs, "player1");
 
         expect(stats.ab).toBe(2);
         expect(stats.hits).toBe(1);
@@ -812,7 +814,8 @@ describe("calculatePlayerStats", () => {
         // OBP: 3 / 4 = .750
         // OPS: 1.750 + .750 = 2.500
 
-        const stats = calculatePlayerStats(logs);
+        const mappedLogs = logs.map((l) => ({ ...l, playerId: "player1" }));
+        const stats = calculatePlayerStats(mappedLogs, "player1");
 
         expect(stats.calculated.slg).toBe("1.750");
         expect(stats.calculated.obp).toBe(".750");
@@ -835,7 +838,8 @@ describe("calculatePlayerStats", () => {
         // SF = sacrifice_fly (0 AB, 1 SF)
         // Total: AB: 5, Hits: 4, BB: 1, SF: 1, RBI: 2, K: 1
 
-        const stats = calculatePlayerStats(logs);
+        const mappedLogs = logs.map((l) => ({ ...l, playerId: "player1" }));
+        const stats = calculatePlayerStats(mappedLogs, "player1");
 
         expect(stats.ab).toBe(5);
         expect(stats.hits).toBe(4);
@@ -857,7 +861,8 @@ describe("calculatePlayerStats", () => {
         ];
         const logs = outTypes.map((type) => ({ eventType: type }));
 
-        const stats = calculatePlayerStats(logs);
+        const mappedLogs = logs.map((l) => ({ ...l, playerId: "player1" }));
+        const stats = calculatePlayerStats(mappedLogs, "player1");
 
         expect(stats.ab).toBe(5);
         expect(stats.details.Outs).toBe(5);
@@ -867,7 +872,8 @@ describe("calculatePlayerStats", () => {
     it("should handle error and fielders_choice database values", () => {
         const logs = [{ eventType: "error" }, { eventType: "fielders_choice" }];
 
-        const stats = calculatePlayerStats(logs);
+        const mappedLogs = logs.map((l) => ({ ...l, playerId: "player1" }));
+        const stats = calculatePlayerStats(mappedLogs, "player1");
 
         expect(stats.ab).toBe(2);
         expect(stats.details.E).toBe(1);
@@ -883,10 +889,34 @@ describe("calculatePlayerStats", () => {
                 baseState: { isOpponent: true },
             },
         ];
-        const stats = calculatePlayerStats(logs);
+        const mappedLogs = logs.map((l) => ({ ...l, playerId: "player1" }));
+        const stats = calculatePlayerStats(mappedLogs, "player1");
         expect(stats.ab).toBe(1);
         expect(stats.hits).toBe(1);
         expect(stats.rbi).toBe(0);
+    });
+
+    it("should correctly credit runs to players but not add plate appearances if they only scored", () => {
+        const logs = [
+            // Opponent play where player1 scored (not batter)
+            {
+                playerId: "player2",
+                eventType: "single",
+                rbi: 1,
+                baseState: JSON.stringify({ scored: ["player1"] }),
+            },
+            // Player1's own at-bat where they also scored
+            {
+                playerId: "player1",
+                eventType: "single",
+                rbi: 0,
+                scored: ["player1"],
+            },
+        ];
+        const stats = calculatePlayerStats(logs, "player1");
+        expect(stats.ab).toBe(1);
+        expect(stats.hits).toBe(1);
+        expect(stats.runs).toBe(2);
     });
 
     it("should skip injury_auto_out and INJURY_REMOVE events", () => {
@@ -895,7 +925,8 @@ describe("calculatePlayerStats", () => {
             { eventType: "injury_auto_out", rbi: 0 },
             { eventType: "INJURY_REMOVE", rbi: 0 },
         ];
-        const stats = calculatePlayerStats(logs);
+        const mappedLogs = logs.map((l) => ({ ...l, playerId: "player1" }));
+        const stats = calculatePlayerStats(mappedLogs, "player1");
         expect(stats.ab).toBe(1);
         expect(stats.hits).toBe(1);
     });


### PR DESCRIPTION
[![Render.com PR #219 ENV](https://img.shields.io/badge/Render.com%20PR%20%23219%20ENV-blue)](https://softball-manager-react-router-pr-219.onrender.com/)

This PR adds the ability for users to see how many runs they scored on a per-game basis directly from their player profile stats page.

### Changes include:
- Updating core stat calculations to process `userId` without double counting.
- Storing and fetching a new `scored` array property on game logs.
- Adding a new UI "Runs" badge to the game stats card (`GameStatsCard`) and a runs row to the stats detail drawer (`StatsDetailDrawer`).
- Matching tests for UI components and business logic.
