### PR TITLE
chore: Upgrade React Router to v8 and major dependencies

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -3,5 +3,18 @@ module.exports = {
         ["@babel/preset-env", { targets: { node: "current" } }],
         ["@babel/preset-react", { runtime: "automatic" }],
     ],
-    plugins: ["transform-vite-meta-env"],
+    plugins: [
+        "transform-vite-meta-env",
+        function () {
+            return {
+                visitor: {
+                    MetaProperty(path) {
+                        path.replaceWithSourceString(
+                            "({ env: {}, hot: false })",
+                        );
+                    },
+                },
+            };
+        },
+    ],
 };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,10 +1,10 @@
 module.exports = {
     testEnvironment: "jsdom",
     transform: {
-        "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
+        "^.+\\.(js|jsx|mjs|cjs|ts|tsx)$": "babel-jest",
     },
     transformIgnorePatterns: [
-        "/node_modules/(?!(node-appwrite|node-fetch-native-with-agent)/).+\\.js$",
+        "/node_modules/(?!(node-appwrite|node-fetch-native-with-agent|react-router|@react-router|cookie-es)/).+\\.(js|jsx|mjs|cjs|ts|tsx)$",
     ],
     // Path aliases - @/ covers most cases. Add others only if needed.
     // Keep in sync with vite.config.ts and tsconfig.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,20 @@
                 "@google-cloud/local-auth": "^3.0.1",
                 "@google/genai": "^2.7.0",
                 "@hello-pangea/dnd": "^18.0.1",
-                "@mantine/carousel": "^9.2.2",
-                "@mantine/core": "^9.2.2",
-                "@mantine/dates": "^9.2.2",
-                "@mantine/hooks": "^9.2.2",
-                "@mantine/modals": "^9.2.2",
-                "@mantine/notifications": "^9.2.2",
+                "@mantine/carousel": "^9.4.0",
+                "@mantine/core": "^9.4.0",
+                "@mantine/dates": "^9.4.0",
+                "@mantine/hooks": "^9.4.0",
+                "@mantine/modals": "^9.4.0",
+                "@mantine/notifications": "^9.4.0",
                 "@react-google-maps/api": "^2.20.8",
-                "@react-router/node": "^7.16.0",
-                "@react-router/serve": "^7.16.0",
-                "@sentry/profiling-node": "^10.55.0",
-                "@sentry/react-router": "^10.55.0",
+                "@react-router/node": "^8.0.1",
+                "@react-router/serve": "^8.0.1",
+                "@sentry/profiling-node": "^10.60.0",
+                "@sentry/react-router": "^10.60.0",
                 "@tabler/icons-react": "^3.44.0",
                 "@vercel/react-router": "^1.3.1",
-                "appwrite": "^25.2.0",
+                "appwrite": "^26.0.0",
                 "calendar-link": "^2.11.2",
                 "canvas-confetti": "^1.9.4",
                 "clsx": "^2.1.1",
@@ -33,26 +33,25 @@
                 "embla-carousel-autoplay": "^8.6.0",
                 "embla-carousel-react": "^8.6.0",
                 "firebase": "^12.14.0",
-                "google-auth-library": "^9.15.1",
-                "googleapis": "^146.0.0",
+                "google-auth-library": "^10.7.0",
+                "googleapis": "^173.0.0",
                 "isbot": "^5.1.40",
                 "luxon": "^3.7.2",
-                "node-appwrite": "^25.2.0",
-                "react": "^19.2.6",
-                "react-dom": "^19.2.6",
+                "node-appwrite": "^26.2.0",
+                "react": "^19.2.7",
+                "react-dom": "^19.2.7",
                 "react-imask": "^7.6.1",
                 "react-joyride": "^3.1.0",
                 "react-markdown": "^10.1.0",
-                "react-router": "^7.16.0"
+                "react-router": "^8.0.1"
             },
             "devDependencies": {
                 "@babel/preset-env": "^7.29.7",
                 "@babel/preset-react": "^7.29.7",
                 "@eslint/js": "^9.39.4",
-                "@netlify/vite-plugin-react-router": "^1.0.1",
-                "@react-router/dev": "^7.16.0",
+                "@react-router/dev": "^8.0.1",
                 "@sentry/vite-plugin": "^5.3.0",
-                "@tailwindcss/vite": "^4.0.0",
+                "@tailwindcss/vite": "^4.3.1",
                 "@testing-library/dom": "^10.4.0",
                 "@testing-library/jest-dom": "^6.9.1",
                 "@testing-library/react": "^16.3.2",
@@ -76,11 +75,10 @@
                 "postcss-preset-mantine": "^1.18.0",
                 "postcss-simple-vars": "^7.0.1",
                 "prettier": "3.6.2",
-                "react-router-devtools": "^1.1.10",
-                "tailwindcss": "^4.0.0",
+                "react-router-devtools": "^6.2.1",
+                "tailwindcss": "^4.3.1",
                 "typescript": "^5.9.3",
-                "vite": "^6.4.2",
-                "vite-tsconfig-paths": "^5.1.4"
+                "vite": "^8.1.0"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -89,6 +87,49 @@
             "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@apm-js-collab/code-transformer": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz",
+            "integrity": "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/estree": "^1.0.8",
+                "astring": "^1.9.0",
+                "esquery": "^1.7.0",
+                "meriyah": "^6.1.4",
+                "semifies": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "bin": {
+                "code-transformer": "cli.js"
+            }
+        },
+        "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.5.0.tgz",
+            "integrity": "sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@apm-js-collab/code-transformer": "^0.15.0",
+                "es-module-lexer": "^2.1.0",
+                "magic-string": "^0.30.21",
+                "module-details-from-path": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@apm-js-collab/tracing-hooks": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.10.0.tgz",
+            "integrity": "sha512-2/Z3NTewJTruUkmsSnBC5bJlLNUd9keuD1OLlTEpim4FyLhm6m2Rnfv+wrFdUvFfhmH8CRdiDZBqBrn+wyaGuA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@apm-js-collab/code-transformer": "^0.15.0",
+                "debug": "^4.4.1",
+                "module-details-from-path": "^1.0.4"
+            }
         },
         "node_modules/@asamuzakjp/css-color": {
             "version": "3.2.0",
@@ -135,20 +176,20 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-            "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.5",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-module-transforms": "^7.28.3",
-                "@babel/helpers": "^7.28.4",
-                "@babel/parser": "^7.28.5",
-                "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.28.5",
-                "@babel/types": "^7.28.5",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -465,13 +506,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.4"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2048,9 +2089,9 @@
             "license": "MIT"
         },
         "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-            "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.1.tgz",
+            "integrity": "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==",
             "cpu": [
                 "arm64"
             ],
@@ -2202,7 +2243,6 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
             "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2214,7 +2254,6 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
             "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2225,580 +2264,17 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
             "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
         },
-        "node_modules/@emotion/babel-plugin": {
-            "version": "11.13.5",
-            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
-            "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.16.7",
-                "@babel/runtime": "^7.18.3",
-                "@emotion/hash": "^0.9.2",
-                "@emotion/memoize": "^0.9.0",
-                "@emotion/serialize": "^1.3.3",
-                "babel-plugin-macros": "^3.1.0",
-                "convert-source-map": "^1.5.0",
-                "escape-string-regexp": "^4.0.0",
-                "find-root": "^1.1.0",
-                "source-map": "^0.5.7",
-                "stylis": "4.2.0"
-            }
-        },
-        "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@emotion/cache": {
-            "version": "11.14.0",
-            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
-            "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@emotion/memoize": "^0.9.0",
-                "@emotion/sheet": "^1.4.0",
-                "@emotion/utils": "^1.4.2",
-                "@emotion/weak-memoize": "^0.4.0",
-                "stylis": "4.2.0"
-            }
-        },
-        "node_modules/@emotion/css": {
-            "version": "11.13.5",
-            "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
-            "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@emotion/babel-plugin": "^11.13.5",
-                "@emotion/cache": "^11.13.5",
-                "@emotion/serialize": "^1.3.3",
-                "@emotion/sheet": "^1.4.0",
-                "@emotion/utils": "^1.4.2"
-            }
-        },
-        "node_modules/@emotion/hash": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@emotion/memoize": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@emotion/react": {
-            "version": "11.14.0",
-            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
-            "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.18.3",
-                "@emotion/babel-plugin": "^11.13.5",
-                "@emotion/cache": "^11.14.0",
-                "@emotion/serialize": "^1.3.3",
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-                "@emotion/utils": "^1.4.2",
-                "@emotion/weak-memoize": "^0.4.0",
-                "hoist-non-react-statics": "^3.3.1"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@emotion/serialize": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
-            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@emotion/hash": "^0.9.2",
-                "@emotion/memoize": "^0.9.0",
-                "@emotion/unitless": "^0.10.0",
-                "@emotion/utils": "^1.4.2",
-                "csstype": "^3.0.2"
-            }
-        },
-        "node_modules/@emotion/sheet": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-            "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@emotion/unitless": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-            "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "react": ">=16.8.0"
-            }
-        },
-        "node_modules/@emotion/utils": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
-            "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@emotion/weak-memoize": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-            "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@epic-web/invariant": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
             "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
             "license": "MIT"
-        },
-        "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-            "cpu": [
-                "loong64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-            "cpu": [
-                "mips64el"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-            "cpu": [
-                "s390x"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.9.1",
@@ -3780,6 +3256,62 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@google-cloud/local-auth/node_modules/gaxios": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+            "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "is-stream": "^2.0.0",
+                "node-fetch": "^2.6.9",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@google-cloud/local-auth/node_modules/gcp-metadata": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+            "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "gaxios": "^6.1.1",
+                "google-logging-utils": "^0.0.2",
+                "json-bigint": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@google-cloud/local-auth/node_modules/google-auth-library": {
+            "version": "9.15.1",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+            "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "base64-js": "^1.3.0",
+                "ecdsa-sig-formatter": "^1.0.11",
+                "gaxios": "^6.1.1",
+                "gcp-metadata": "^6.1.0",
+                "gtoken": "^7.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@google-cloud/local-auth/node_modules/google-logging-utils": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+            "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@google/genai": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.7.0.tgz",
@@ -3802,78 +3334,6 @@
                 "@modelcontextprotocol/sdk": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@google/genai/node_modules/gaxios": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-            "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "extend": "^3.0.2",
-                "https-proxy-agent": "^7.0.1",
-                "node-fetch": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@google/genai/node_modules/gcp-metadata": {
-            "version": "8.1.2",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-            "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "gaxios": "^7.0.0",
-                "google-logging-utils": "^1.0.0",
-                "json-bigint": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@google/genai/node_modules/google-auth-library": {
-            "version": "10.6.2",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-            "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "base64-js": "^1.3.0",
-                "ecdsa-sig-formatter": "^1.0.11",
-                "gaxios": "^7.1.4",
-                "gcp-metadata": "8.1.2",
-                "google-logging-utils": "1.1.3",
-                "jws": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@google/genai/node_modules/google-logging-utils": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-            "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@google/genai/node_modules/node-fetch": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-            "license": "MIT",
-            "dependencies": {
-                "data-uri-to-buffer": "^4.0.0",
-                "fetch-blob": "^3.1.4",
-                "formdata-polyfill": "^4.0.10"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/@googlemaps/js-api-loader": {
@@ -3996,7 +3456,6 @@
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
             "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "string-width": "^5.1.2",
@@ -4718,13 +4177,13 @@
             }
         },
         "node_modules/@mantine/carousel": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@mantine/carousel/-/carousel-9.2.2.tgz",
-            "integrity": "sha512-emSvFtMHnwRebdUzPu/f53iF+7xas7JHDdYNuTyGx9Gdfy8BPJSJQrSOUIO3UF6kKV9G1/nCv+SySSUfzCyvgQ==",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@mantine/carousel/-/carousel-9.4.0.tgz",
+            "integrity": "sha512-kPXKO7+RWGFEt8OKPmii8JG0Dq4Pdrx1LzHlsHv12Zd39h/DZiO1MYia9DBt52n06V6xpb1sTJUCQ9mjGYdCfw==",
             "license": "MIT",
             "peerDependencies": {
-                "@mantine/core": "9.2.2",
-                "@mantine/hooks": "9.2.2",
+                "@mantine/core": "9.4.0",
+                "@mantine/hooks": "9.4.0",
                 "embla-carousel": ">=8.0.0",
                 "embla-carousel-react": ">=8.0.0",
                 "react": "^19.2.0",
@@ -4732,100 +4191,93 @@
             }
         },
         "node_modules/@mantine/core": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@mantine/core/-/core-9.2.2.tgz",
-            "integrity": "sha512-j4d7dwKkrYPP9Lb7ut1u0OodwmosIaKK4azK4GMoTKq1+7TKRrJPxB1vkDjkbOcd+jbUt0qn6EkJdsSMKVcIIw==",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@mantine/core/-/core-9.4.0.tgz",
+            "integrity": "sha512-BvTzaJ5Nut4ZiWLCcy1/cRXE8yjCgxsBhyAynY1pEg6XBw/fChEqSgbEB2dybOnkiAxvYt89TrnTrBBo9qJtmg==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/react": "^0.27.19",
                 "clsx": "^2.1.1",
                 "react-number-format": "^5.4.5",
                 "react-remove-scroll": "^2.7.2",
-                "type-fest": "^5.6.0"
+                "type-fest": "^5.7.0"
             },
             "peerDependencies": {
-                "@mantine/hooks": "9.2.2",
+                "@mantine/hooks": "9.4.0",
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0"
             }
         },
         "node_modules/@mantine/dates": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-9.2.2.tgz",
-            "integrity": "sha512-6/O5f/u2NjJLKoLvZmSJCo6qQqPg627XjfpeUYqOx/h9I2W36eVaKghM4YObPpfkPZMIojaa3iz82Nw3lmZO3w==",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-9.4.0.tgz",
+            "integrity": "sha512-15iCWxykutEVoFUPTq4z+An3YQZb7UH6Fwzb3stsVhTMLm6FyGLYSSB6PL+9sBV1TPllIJSm1IizY2SSTDGqQQ==",
             "license": "MIT",
             "dependencies": {
                 "clsx": "^2.1.1"
             },
             "peerDependencies": {
-                "@mantine/core": "9.2.2",
-                "@mantine/hooks": "9.2.2",
+                "@mantine/core": "9.4.0",
+                "@mantine/hooks": "9.4.0",
                 "dayjs": ">=1.0.0",
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0"
             }
         },
         "node_modules/@mantine/hooks": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.2.2.tgz",
-            "integrity": "sha512-E0eKEMv47Xo+QVKYj2buzLJURcO/Qfb12EvM4mjKlXPuTqYhl+Fvg7Sg+xHmta8iTtBvo/5G+iNeqc4pfs8eaA==",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.4.0.tgz",
+            "integrity": "sha512-SUkge8KlhyLoSSKhEHERx7jLotNu632kldhQPlLn5kbOuJixoEbU8fKcuwpXSsZTtzRgCCT2IkoN+rORhtZTHg==",
             "license": "MIT",
             "peerDependencies": {
                 "react": "^19.2.0"
             }
         },
         "node_modules/@mantine/modals": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-9.2.2.tgz",
-            "integrity": "sha512-OiLHaDrHw7ArCBXzxap+lsMdGwLiyOWD+HQ9pqwwyczmvwcgVgqcFi4gq4eOs8GGZc/e6WaQ0uKbYvlVBgK5wA==",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-9.4.0.tgz",
+            "integrity": "sha512-XFili5IbS+sLV5n98VjKTMcPmgahsXva1VO4xS5kPM9UtlAmA8c1/KUQd+0lJd0JgwL7I6S2k6/rgPFVqZ94HA==",
             "license": "MIT",
             "peerDependencies": {
-                "@mantine/core": "9.2.2",
-                "@mantine/hooks": "9.2.2",
+                "@mantine/core": "9.4.0",
+                "@mantine/hooks": "9.4.0",
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0"
             }
         },
         "node_modules/@mantine/notifications": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-9.2.2.tgz",
-            "integrity": "sha512-7pNVA1wy+QJmzQiXXP65o9pzg/NLpLNU9wE0nLU2chjpvuqvfu1KP1lOB3097rebLxYmmrE25Dn4hxfSrHwCmw==",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-9.4.0.tgz",
+            "integrity": "sha512-B7ZiuwGlb6lI97OgUeNdz77o/KifJqDMJBo7QyWpfmchbqf3Tp7mZMxfn4SnILQCtFmEg6qKji7lt9tgOA279g==",
             "license": "MIT",
             "dependencies": {
-                "@mantine/store": "9.2.2",
+                "@mantine/store": "9.4.0",
                 "react-transition-group": "4.4.5"
             },
             "peerDependencies": {
-                "@mantine/core": "9.2.2",
-                "@mantine/hooks": "9.2.2",
+                "@mantine/core": "9.4.0",
+                "@mantine/hooks": "9.4.0",
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0"
             }
         },
         "node_modules/@mantine/store": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@mantine/store/-/store-9.2.2.tgz",
-            "integrity": "sha512-ZzS1yERapPURUG1vs7G+lD+oc8AZKissP1eUzefpyOAgEoEJXjOckc5/voiik3dcc/WP4AE9GQsT3Z4cS27E/A==",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@mantine/store/-/store-9.4.0.tgz",
+            "integrity": "sha512-BiJXxIdCBtfcODunPpzAKLuiIpxDeGo1mRd2gmzgSStV5BMxWpM0zEL8S49rN+xuFARwzGp3t1ks7B6EqthH8Q==",
             "license": "MIT",
             "peerDependencies": {
                 "react": "^19.2.0"
             }
         },
-        "node_modules/@mjackson/node-fetch-server": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@mjackson/node-fetch-server/-/node-fetch-server-0.2.0.tgz",
-            "integrity": "sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==",
-            "license": "MIT"
-        },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-            "dev": true,
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
+                "@tybys/wasm-util": "^0.10.3"
             },
             "funding": {
                 "type": "github",
@@ -4834,24 +4286,6 @@
             "peerDependencies": {
                 "@emnapi/core": "^1.7.1",
                 "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/@netlify/vite-plugin-react-router": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@netlify/vite-plugin-react-router/-/vite-plugin-react-router-1.0.1.tgz",
-            "integrity": "sha512-JE32RJ6PamX6Yf2yyys7NLaKK4ppcDwuL6mk7NDZ7rt4EWUm+5bz/YjMcLz9uXyo1jDPlWjaUcqRC2MUZKt2DA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@react-router/node": "^7.0.1",
-                "isbot": "^5.0.0",
-                "react-router": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "vite": ">=5.0.0"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -4889,13 +4323,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@one-ini/wasm": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
-            "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@opentelemetry/api": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -4918,9 +4345,9 @@
             }
         },
         "node_modules/@opentelemetry/core": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-            "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4950,12 +4377,12 @@
             }
         },
         "node_modules/@opentelemetry/resources": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
-            "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+            "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "2.7.1",
+                "@opentelemetry/core": "2.8.0",
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
@@ -4966,13 +4393,13 @@
             }
         },
         "node_modules/@opentelemetry/sdk-trace-base": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
-            "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+            "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "2.7.1",
-                "@opentelemetry/resources": "2.7.1",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/resources": "2.8.0",
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
@@ -4991,11 +4418,19 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@oxc-project/types": {
+            "version": "0.137.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+            "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
             "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "engines": {
@@ -5079,60 +4514,29 @@
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
             "license": "BSD-3-Clause"
         },
-        "node_modules/@radix-ui/number": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
-            "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@radix-ui/primitive": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
-            "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+            "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@radix-ui/react-accordion": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.3.tgz",
-            "integrity": "sha512-RIQ15mrcvqIkDARJeERSuXSry2N8uYnxkdDetpfmalT/+0ntOXLkFOsh9iwlAsCv+qcmhZjbdJogIm6WBa6c4A==",
+            "version": "1.2.14",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.14.tgz",
+            "integrity": "sha512-iE8YB9nmTBH8zd73ofBISZ8JCzgMoMkATJr7qDwa6u5F1+7mTM81V6fa71jgZ65rpjVpecDf1vSnwIFP9Ly1zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@radix-ui/primitive": "1.1.1",
-                "@radix-ui/react-collapsible": "1.1.3",
-                "@radix-ui/react-collection": "1.1.2",
-                "@radix-ui/react-compose-refs": "1.1.1",
-                "@radix-ui/react-context": "1.1.1",
-                "@radix-ui/react-direction": "1.1.0",
-                "@radix-ui/react-id": "1.1.0",
-                "@radix-ui/react-primitive": "2.0.2",
-                "@radix-ui/react-use-controllable-state": "1.1.0"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "@types/react-dom": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "@types/react-dom": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@radix-ui/react-arrow": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.2.tgz",
-            "integrity": "sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@radix-ui/react-primitive": "2.0.2"
+                "@radix-ui/primitive": "1.1.4",
+                "@radix-ui/react-collapsible": "1.1.14",
+                "@radix-ui/react-collection": "1.1.10",
+                "@radix-ui/react-compose-refs": "1.1.3",
+                "@radix-ui/react-context": "1.1.4",
+                "@radix-ui/react-direction": "1.1.2",
+                "@radix-ui/react-id": "1.1.2",
+                "@radix-ui/react-primitive": "2.1.6",
+                "@radix-ui/react-use-controllable-state": "1.2.3"
             },
             "peerDependencies": {
                 "@types/react": "*",
@@ -5150,20 +4554,20 @@
             }
         },
         "node_modules/@radix-ui/react-collapsible": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.3.tgz",
-            "integrity": "sha512-jFSerheto1X03MUC0g6R7LedNW9EEGWdg9W1+MlpkMLwGkgkbUXLPBH/KIuWKXUoeYRVY11llqbTBDzuLg7qrw==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.14.tgz",
+            "integrity": "sha512-9bT+FvifX1FK2Mj6UEsTdyu0cN3JaA3KdfhaBao+ONrYFy/pyOy3TU1TNw7iOk1o+0hOEq67RojlUUmoFGwxyA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@radix-ui/primitive": "1.1.1",
-                "@radix-ui/react-compose-refs": "1.1.1",
-                "@radix-ui/react-context": "1.1.1",
-                "@radix-ui/react-id": "1.1.0",
-                "@radix-ui/react-presence": "1.1.2",
-                "@radix-ui/react-primitive": "2.0.2",
-                "@radix-ui/react-use-controllable-state": "1.1.0",
-                "@radix-ui/react-use-layout-effect": "1.1.0"
+                "@radix-ui/primitive": "1.1.4",
+                "@radix-ui/react-compose-refs": "1.1.3",
+                "@radix-ui/react-context": "1.1.4",
+                "@radix-ui/react-id": "1.1.2",
+                "@radix-ui/react-presence": "1.1.6",
+                "@radix-ui/react-primitive": "2.1.6",
+                "@radix-ui/react-use-controllable-state": "1.2.3",
+                "@radix-ui/react-use-layout-effect": "1.1.2"
             },
             "peerDependencies": {
                 "@types/react": "*",
@@ -5181,16 +4585,16 @@
             }
         },
         "node_modules/@radix-ui/react-collection": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.2.tgz",
-            "integrity": "sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==",
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.10.tgz",
+            "integrity": "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@radix-ui/react-compose-refs": "1.1.1",
-                "@radix-ui/react-context": "1.1.1",
-                "@radix-ui/react-primitive": "2.0.2",
-                "@radix-ui/react-slot": "1.1.2"
+                "@radix-ui/react-compose-refs": "1.1.3",
+                "@radix-ui/react-context": "1.1.4",
+                "@radix-ui/react-primitive": "2.1.6",
+                "@radix-ui/react-slot": "1.3.0"
             },
             "peerDependencies": {
                 "@types/react": "*",
@@ -5208,9 +4612,9 @@
             }
         },
         "node_modules/@radix-ui/react-compose-refs": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
-            "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+            "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -5224,9 +4628,9 @@
             }
         },
         "node_modules/@radix-ui/react-context": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
-            "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+            "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -5240,99 +4644,29 @@
             }
         },
         "node_modules/@radix-ui/react-direction": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
-            "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@radix-ui/react-dismissable-layer": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz",
-            "integrity": "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@radix-ui/primitive": "1.1.1",
-                "@radix-ui/react-compose-refs": "1.1.1",
-                "@radix-ui/react-primitive": "2.0.2",
-                "@radix-ui/react-use-callback-ref": "1.1.0",
-                "@radix-ui/react-use-escape-keydown": "1.1.0"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "@types/react-dom": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "@types/react-dom": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@radix-ui/react-focus-guards": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
-            "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@radix-ui/react-focus-scope": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.2.tgz",
-            "integrity": "sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+            "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "@radix-ui/react-compose-refs": "1.1.1",
-                "@radix-ui/react-primitive": "2.0.2",
-                "@radix-ui/react-use-callback-ref": "1.1.0"
-            },
             "peerDependencies": {
                 "@types/react": "*",
-                "@types/react-dom": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
-                    "optional": true
-                },
-                "@types/react-dom": {
                     "optional": true
                 }
             }
         },
         "node_modules/@radix-ui/react-id": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
-            "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+            "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@radix-ui/react-use-layout-effect": "1.1.0"
+                "@radix-ui/react-use-layout-effect": "1.1.2"
             },
             "peerDependencies": {
                 "@types/react": "*",
@@ -5344,73 +4678,14 @@
                 }
             }
         },
-        "node_modules/@radix-ui/react-popper": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.2.tgz",
-            "integrity": "sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@floating-ui/react-dom": "^2.0.0",
-                "@radix-ui/react-arrow": "1.1.2",
-                "@radix-ui/react-compose-refs": "1.1.1",
-                "@radix-ui/react-context": "1.1.1",
-                "@radix-ui/react-primitive": "2.0.2",
-                "@radix-ui/react-use-callback-ref": "1.1.0",
-                "@radix-ui/react-use-layout-effect": "1.1.0",
-                "@radix-ui/react-use-rect": "1.1.0",
-                "@radix-ui/react-use-size": "1.1.0",
-                "@radix-ui/rect": "1.1.0"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "@types/react-dom": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "@types/react-dom": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@radix-ui/react-portal": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.4.tgz",
-            "integrity": "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@radix-ui/react-primitive": "2.0.2",
-                "@radix-ui/react-use-layout-effect": "1.1.0"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "@types/react-dom": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "@types/react-dom": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@radix-ui/react-presence": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
-            "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+            "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@radix-ui/react-compose-refs": "1.1.1",
-                "@radix-ui/react-use-layout-effect": "1.1.0"
+                "@radix-ui/react-use-layout-effect": "1.1.2"
             },
             "peerDependencies": {
                 "@types/react": "*",
@@ -5428,57 +4703,13 @@
             }
         },
         "node_modules/@radix-ui/react-primitive": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
-            "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@radix-ui/react-slot": "1.1.2"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "@types/react-dom": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "@types/react-dom": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@radix-ui/react-select": {
             "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.6.tgz",
-            "integrity": "sha512-T6ajELxRvTuAMWH0YmRJ1qez+x4/7Nq7QIx7zJ0VK3qaEWdnWpNbEDnmWldG1zBDwqrLy5aLMUWcoGirVj5kMg==",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+            "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@radix-ui/number": "1.1.0",
-                "@radix-ui/primitive": "1.1.1",
-                "@radix-ui/react-collection": "1.1.2",
-                "@radix-ui/react-compose-refs": "1.1.1",
-                "@radix-ui/react-context": "1.1.1",
-                "@radix-ui/react-direction": "1.1.0",
-                "@radix-ui/react-dismissable-layer": "1.1.5",
-                "@radix-ui/react-focus-guards": "1.1.1",
-                "@radix-ui/react-focus-scope": "1.1.2",
-                "@radix-ui/react-id": "1.1.0",
-                "@radix-ui/react-popper": "1.2.2",
-                "@radix-ui/react-portal": "1.1.4",
-                "@radix-ui/react-primitive": "2.0.2",
-                "@radix-ui/react-slot": "1.1.2",
-                "@radix-ui/react-use-callback-ref": "1.1.0",
-                "@radix-ui/react-use-controllable-state": "1.1.0",
-                "@radix-ui/react-use-layout-effect": "1.1.0",
-                "@radix-ui/react-use-previous": "1.1.0",
-                "@radix-ui/react-visually-hidden": "1.1.2",
-                "aria-hidden": "^1.2.4",
-                "react-remove-scroll": "^2.6.3"
+                "@radix-ui/react-slot": "1.3.0"
             },
             "peerDependencies": {
                 "@types/react": "*",
@@ -5496,30 +4727,14 @@
             }
         },
         "node_modules/@radix-ui/react-slot": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
-            "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+            "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@radix-ui/react-compose-refs": "1.1.1"
+                "@radix-ui/react-compose-refs": "1.1.3"
             },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@radix-ui/react-use-callback-ref": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
-            "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
-            "dev": true,
-            "license": "MIT",
             "peerDependencies": {
                 "@types/react": "*",
                 "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -5531,13 +4746,14 @@
             }
         },
         "node_modules/@radix-ui/react-use-controllable-state": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
-            "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+            "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@radix-ui/react-use-callback-ref": "1.1.0"
+                "@radix-ui/react-use-effect-event": "0.0.3",
+                "@radix-ui/react-use-layout-effect": "1.1.2"
             },
             "peerDependencies": {
                 "@types/react": "*",
@@ -5549,14 +4765,14 @@
                 }
             }
         },
-        "node_modules/@radix-ui/react-use-escape-keydown": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
-            "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+        "node_modules/@radix-ui/react-use-effect-event": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+            "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@radix-ui/react-use-callback-ref": "1.1.0"
+                "@radix-ui/react-use-layout-effect": "1.1.2"
             },
             "peerDependencies": {
                 "@types/react": "*",
@@ -5569,105 +4785,20 @@
             }
         },
         "node_modules/@radix-ui/react-use-layout-effect": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
-            "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@radix-ui/react-use-previous": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
-            "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@radix-ui/react-use-rect": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
-            "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@radix-ui/rect": "1.1.0"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@radix-ui/react-use-size": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
-            "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@radix-ui/react-use-layout-effect": "1.1.0"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@radix-ui/react-visually-hidden": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.2.tgz",
-            "integrity": "sha512-1SzA4ns2M1aRlvxErqhLHsBHoS5eI5UUcI2awAMgGUp4LoaoWOKYmvqDY2s/tltuPkh3Yk77YF/r3IRj+Amx4Q==",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+            "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "@radix-ui/react-primitive": "2.0.2"
-            },
             "peerDependencies": {
                 "@types/react": "*",
-                "@types/react-dom": "*",
-                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
                     "optional": true
-                },
-                "@types/react-dom": {
-                    "optional": true
                 }
             }
-        },
-        "node_modules/@radix-ui/rect": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
-            "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@react-google-maps/api": {
             "version": "2.20.8",
@@ -5700,54 +4831,53 @@
             "license": "MIT"
         },
         "node_modules/@react-router/dev": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.16.0.tgz",
-            "integrity": "sha512-E/uNYnHbo+wepw+FudGwuN6au6y4dOfVuRRANYdCp5T+tLvGU/09s2uGzNQsxqushyae9wvWTLY0qMvvgowIyg==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-8.0.1.tgz",
+            "integrity": "sha512-Xc1WfN4Ql9j271iJnvIJqxLvN5cyjUW/X4JsGw2j/0lET12UFnpNTpBLYXmLNci8vfpmfKI06KSixZ4pjIT4Bw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/core": "^7.27.7",
-                "@babel/generator": "^7.27.5",
-                "@babel/parser": "^7.27.7",
-                "@babel/plugin-syntax-jsx": "^7.27.1",
-                "@babel/preset-typescript": "^7.27.1",
-                "@babel/traverse": "^7.27.7",
-                "@babel/types": "^7.27.7",
-                "@react-router/node": "7.16.0",
-                "@remix-run/node-fetch-server": "^0.13.0",
+                "@babel/core": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/plugin-syntax-jsx": "^7.29.7",
+                "@babel/preset-typescript": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@react-router/node": "8.0.1",
+                "@remix-run/node-fetch-server": "^0.13.3",
                 "arg": "^5.0.1",
-                "babel-dead-code-elimination": "^1.0.6",
-                "chokidar": "^4.0.0",
-                "dedent": "^1.5.3",
-                "es-module-lexer": "^1.3.1",
-                "exit-hook": "2.2.1",
-                "isbot": "^5.1.11",
-                "jsesc": "3.0.2",
-                "lodash": "^4.17.21",
-                "p-map": "^7.0.3",
-                "pathe": "^1.1.2",
+                "babel-dead-code-elimination": "^1.0.12",
+                "chokidar": "^5.0.0",
+                "dedent": "^1.7.2",
+                "es-module-lexer": "^2.1.0",
+                "exit-hook": "5.1.0",
+                "isbot": "^5.1.40",
+                "jsesc": "3.1.0",
+                "lodash": "^4.18.1",
+                "p-map": "^7.0.4",
+                "pathe": "^2.0.3",
                 "picocolors": "^1.1.1",
-                "pkg-types": "^2.3.0",
-                "prettier": "^3.6.2",
-                "react-refresh": "^0.14.0",
-                "semver": "^7.3.7",
-                "tinyglobby": "^0.2.14",
-                "valibot": "^1.2.0",
-                "vite-node": "^3.2.2"
+                "pkg-types": "^2.3.1",
+                "prettier": "^3.8.3",
+                "react-refresh": "^0.18.0",
+                "semver": "^7.8.1",
+                "tinyglobby": "^0.2.16",
+                "valibot": "^1.4.1"
             },
             "bin": {
-                "react-router": "bin.js"
+                "react-router": "bin.cjs"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=22.22.0"
             },
             "peerDependencies": {
-                "@react-router/serve": "^7.16.0",
-                "@vitejs/plugin-rsc": "~0.5.21",
-                "react-router": "^7.16.0",
-                "react-server-dom-webpack": "^19.2.3",
+                "@react-router/serve": "^8.0.1",
+                "@vitejs/plugin-rsc": "~0.5.26",
+                "react-router": "^8.0.1",
+                "react-server-dom-webpack": "^19.2.7",
                 "typescript": "^5.1.0 || ^6.0.0",
-                "vite": "^5.1.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-                "wrangler": "^3.28.2 || ^4.0.0"
+                "vite": "^7.0.0 || ^8.0.0",
+                "wrangler": "^4.0.0"
             },
             "peerDependenciesMeta": {
                 "@react-router/serve": {
@@ -5767,20 +4897,35 @@
                 }
             }
         },
-        "node_modules/@react-router/express": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.16.0.tgz",
-            "integrity": "sha512-nE+yZ9J8fJjVR7UrnAYzOWcvAdI0HxHKjzizOxpDREcNCt38EFoMqc2gi4vEbQUVvj67Uygv/iACuc/AAAfj3Q==",
+        "node_modules/@react-router/dev/node_modules/prettier": {
+            "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+            "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
             "license": "MIT",
-            "dependencies": {
-                "@react-router/node": "7.16.0"
+            "bin": {
+                "prettier": "bin/prettier.cjs"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/@react-router/express": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@react-router/express/-/express-8.0.1.tgz",
+            "integrity": "sha512-FWErptC9nFtaRo3SRsHgO60C1bCpUU35ATDvJulQIYXxDsXUdicyhJWCrl5DeEO2pUeqyPA4taP7l7aWkz2qZQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@react-router/node": "8.0.1"
+            },
+            "engines": {
+                "node": ">=22.22.0"
             },
             "peerDependencies": {
-                "express": "^4.17.1 || ^5",
-                "react-router": "7.16.0",
+                "express": "^4.22.2 || ^5",
+                "react-router": "8.0.1",
                 "typescript": "^5.1.0 || ^6.0.0"
             },
             "peerDependenciesMeta": {
@@ -5790,18 +4935,18 @@
             }
         },
         "node_modules/@react-router/node": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.16.0.tgz",
-            "integrity": "sha512-3S54GArZETvcBHt0cFNJS5ZU66bCNVOoS44MVcGjiGjArBXvWx8xIQ5FO9n1azKGEBpDmJN7NbA+cf3oMCJv3g==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@react-router/node/-/node-8.0.1.tgz",
+            "integrity": "sha512-XUtOdjgOtFXe4XxkO28km51l++AYL7A3mk4Sozm7hr3ROY/9qE+9EoPHw0gEv4FQEgY7a/6XnzDL5dB+zNt7GA==",
             "license": "MIT",
             "dependencies": {
-                "@mjackson/node-fetch-server": "^0.2.0"
+                "@remix-run/node-fetch-server": "^0.13.3"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=22.22.0"
             },
             "peerDependencies": {
-                "react-router": "7.16.0",
+                "react-router": "8.0.1",
                 "typescript": "^5.1.0 || ^6.0.0"
             },
             "peerDependenciesMeta": {
@@ -5811,28 +4956,28 @@
             }
         },
         "node_modules/@react-router/serve": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.16.0.tgz",
-            "integrity": "sha512-ZI26LhXH65HP6z89+VzTK4XXDibnJczCUNQOgZIabKXSx8bmSzwujHe0brFc/eBW8N+tFBn/OZ2UuqELi9MwBg==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-8.0.1.tgz",
+            "integrity": "sha512-7kCZhE4cT0y4JMHpG1bJoIfy9tYWSqDqzZUYylQL9UCLYg9vq84X33UC6Xi9eQB9SRAuDM5iKQtTrGEstIMVKA==",
             "license": "MIT",
             "dependencies": {
-                "@mjackson/node-fetch-server": "^0.2.0",
-                "@react-router/express": "7.16.0",
-                "@react-router/node": "7.16.0",
+                "@react-router/express": "8.0.1",
+                "@react-router/node": "8.0.1",
+                "@remix-run/node-fetch-server": "^0.13.3",
                 "compression": "^1.8.1",
-                "express": "^4.19.2",
-                "get-port": "5.1.1",
+                "express": "^5.2.1",
+                "get-port": "7.2.0",
                 "morgan": "^1.10.1",
                 "source-map-support": "^0.5.21"
             },
             "bin": {
-                "react-router-serve": "bin.js"
+                "react-router-serve": "bin.cjs"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=22.22.0"
             },
             "peerDependencies": {
-                "react-router": "7.16.0"
+                "react-router": "8.0.1"
             }
         },
         "node_modules/@remix-run/node-fetch-server": {
@@ -5841,23 +4986,10 @@
             "integrity": "sha512-UfjOXed/DQteaM5VyTfqTeGpHwyL2J5aoRGY6cydip4tt1ehNNeSwuXCC7AEGE0RWBs/7bgKxYkL/B/+UDe4AA==",
             "license": "MIT"
         },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
-            "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
-            "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+            "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
             "cpu": [
                 "arm64"
             ],
@@ -5865,12 +4997,15 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
-            "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+            "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
             "cpu": [
                 "arm64"
             ],
@@ -5878,12 +5013,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
-            "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+            "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
             "cpu": [
                 "x64"
             ],
@@ -5891,25 +5029,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
-        },
-        "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
-            "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
-            "cpu": [
-                "arm64"
             ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
-            "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+            "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
             "cpu": [
                 "x64"
             ],
@@ -5917,44 +5045,31 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
-            "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+            "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
             "cpu": [
                 "arm"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
-            "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
-            "cpu": [
-                "arm"
             ],
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
-            "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+            "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
             "cpu": [
                 "arm64"
             ],
@@ -5965,12 +5080,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
-            "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+            "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
             "cpu": [
                 "arm64"
             ],
@@ -5981,44 +5099,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
-            "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
-            "cpu": [
-                "loong64"
-            ],
-            "libc": [
-                "glibc"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
-            "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
-            "cpu": [
-                "loong64"
-            ],
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
-            "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+            "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
             "cpu": [
                 "ppc64"
             ],
@@ -6029,60 +5118,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
-            "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
-            "cpu": [
-                "ppc64"
-            ],
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
-            "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "libc": [
-                "glibc"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
-            "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
-            "cpu": [
-                "riscv64"
-            ],
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
-            "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+            "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
             "cpu": [
                 "s390x"
             ],
@@ -6093,12 +5137,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-            "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+            "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
             "cpu": [
                 "x64"
             ],
@@ -6109,12 +5156,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
-            "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+            "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
             "cpu": [
                 "x64"
             ],
@@ -6125,25 +5175,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
-            "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
-            "cpu": [
-                "x64"
             ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
-            "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+            "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
             "cpu": [
                 "arm64"
             ],
@@ -6151,12 +5191,64 @@
             "optional": true,
             "os": [
                 "openharmony"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
-            "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+            "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+            "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
             "cpu": [
                 "arm64"
             ],
@@ -6164,25 +5256,15 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
-            "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
-            "cpu": [
-                "ia32"
             ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
-            "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+            "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
             "cpu": [
                 "x64"
             ],
@@ -6190,84 +5272,47 @@
             "optional": true,
             "os": [
                 "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "license": "MIT"
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+            "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
             ]
         },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
-            "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+            "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
             "cpu": [
                 "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
             "os": [
-                "win32"
+                "linux"
             ]
-        },
-        "node_modules/@sentry-internal/browser-utils": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.55.0.tgz",
-            "integrity": "sha512-zUvyBr13EK0evKsSTzwSimRzZ3P9kugS32dLCj3ea5gNN+/DFtU/GsMTdcIQDhusEDraIlH17AGgqJH5gUAv5w==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry/core": "10.55.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@sentry-internal/feedback": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.55.0.tgz",
-            "integrity": "sha512-32X9WW1xs5DjCRlp89QJ/PLw4kbTIX6MsBDXN2RBN1nWBjm/2WcwXqO/v/WoIS4W2kTWXcZnQwalLSI22Fp33A==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry/core": "10.55.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@sentry-internal/node-cpu-profiler": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/node-cpu-profiler/-/node-cpu-profiler-2.4.1.tgz",
-            "integrity": "sha512-Wnkik+RLvRUZEB8Zx5ofgPdcC8bCSoiUUiyH6TorrLK6PBPerbjK48c2GsJf6l5Hc5GAhA3fitueVLATB0XhWQ==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "detect-libc": "^2.0.3",
-                "node-abi": "^3.73.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@sentry-internal/replay": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.55.0.tgz",
-            "integrity": "sha512-OkQpANGwYU5UKfwLk6Y+NpESRC8nrLBjawRDLwF6cJ8HpNScOuNNJDEJEGwXHVkJPH0pcIixsH8y0Qfcltq6Xw==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry-internal/browser-utils": "10.55.0",
-                "@sentry/core": "10.55.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@sentry-internal/replay-canvas": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.55.0.tgz",
-            "integrity": "sha512-lu/y7k9cK7FZ/qJpL0fBX4WqK6IFa/+bTPhedEaC5UpzjUNP7BfXt0H+R7q9CHWmp20Ffh/wGfO3j7O+Tv2MAA==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry-internal/replay": "10.55.0",
-                "@sentry/core": "10.55.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
         },
         "node_modules/@sentry/babel-plugin-component-annotate": {
             "version": "5.3.0",
@@ -6279,16 +5324,28 @@
             }
         },
         "node_modules/@sentry/browser": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.55.0.tgz",
-            "integrity": "sha512-5n1kxmW1m4j16ZDV9kt+Zo5uafFnKTy7s5YyEcGnC45KnOiO1Gy+QFd3woXns1K5GNxpjF7oOOc6tXgZLuXnQQ==",
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.60.0.tgz",
+            "integrity": "sha512-20vzPKGrmupJPCaWd+soCOLkZRwKZxt0AVF4XGPNoGp7D7wVPRlHf+FWwVMx+rRRkahKupFefM2D9YoiUiBeag==",
             "license": "MIT",
             "dependencies": {
-                "@sentry-internal/browser-utils": "10.55.0",
-                "@sentry-internal/feedback": "10.55.0",
-                "@sentry-internal/replay": "10.55.0",
-                "@sentry-internal/replay-canvas": "10.55.0",
-                "@sentry/core": "10.55.0"
+                "@sentry/browser-utils": "10.60.0",
+                "@sentry/core": "10.60.0",
+                "@sentry/feedback": "10.60.0",
+                "@sentry/replay": "10.60.0",
+                "@sentry/replay-canvas": "10.60.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/browser-utils": {
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.60.0.tgz",
+            "integrity": "sha512-YhdPeMJnMaKVi5NQ2tD9RJ2AxU7cav5khmiMHFppmbP3I3Os2EHVaQjAVb6/ePAINr/d5mj5SxpnWmFX17iXsg==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "10.60.0"
             },
             "engines": {
                 "node": ">=18"
@@ -6638,29 +5695,50 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/@sentry/conventions": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.12.0.tgz",
+            "integrity": "sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@sentry/core": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.55.0.tgz",
-            "integrity": "sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ==",
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.60.0.tgz",
+            "integrity": "sha512-szN7ccOJAEaLb1BBQzCQhABGMTJmKNUk0G2sc7rWhajeXoZoMKIbNkI9RvJrFuV69cbad/d/BKGBjbpJhySAzw==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
+        "node_modules/@sentry/feedback": {
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.60.0.tgz",
+            "integrity": "sha512-RcGUgaI8yrIXunhNLpdNLsBUJIDvnEGDRmFhC5v0oMltoGtovrIqrEhPXEiSWQvNB0x4q33ejkLeJRJoSDOp2w==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "10.60.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@sentry/node": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.55.0.tgz",
-            "integrity": "sha512-+fB/ByoHVWPLGgoafYciiMatTNyX1FHj1bsqZBN+Pw3McbuEU1nwCPLt9zuyZZiWlQtXKsyuACS4ZhXnID5l8A==",
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.60.0.tgz",
+            "integrity": "sha512-u//paUrkKaCr0oNn7r7UulGydkYMSkU1wQOIpG/P/jf7psZWnyXhgeszHzUfZXo6pCdxXG9z9viPvzGjqPQN7A==",
             "license": "MIT",
             "dependencies": {
                 "@opentelemetry/api": "^1.9.1",
-                "@opentelemetry/core": "^2.6.1",
                 "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/sdk-trace-base": "^2.6.1",
                 "@opentelemetry/semantic-conventions": "^1.40.0",
-                "@sentry/core": "10.55.0",
-                "@sentry/node-core": "10.55.0",
-                "@sentry/opentelemetry": "10.55.0",
+                "@sentry/core": "10.60.0",
+                "@sentry/node-core": "10.60.0",
+                "@sentry/opentelemetry": "10.60.0",
+                "@sentry/server-utils": "10.60.0",
                 "import-in-the-middle": "^3.0.0"
             },
             "engines": {
@@ -6668,13 +5746,14 @@
             }
         },
         "node_modules/@sentry/node-core": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.55.0.tgz",
-            "integrity": "sha512-M8XMMIk9Y0PGZoEt37Oe5dQCdqDdJlBcwLXidpz/s5k4QtJvCO/BbtcivcuKI2htw5FwxJkSrHUzRvT36tlDpg==",
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.60.0.tgz",
+            "integrity": "sha512-aXi9ixvP+hgUZPPZCRwMNHgY2I0gkSeoAKAUuysDJhWDmrygwfGdlkbGmmtW6PQjtMYFx69Igt5btvhjEBoJTw==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/core": "10.55.0",
-                "@sentry/opentelemetry": "10.55.0",
+                "@sentry/conventions": "^0.12.0",
+                "@sentry/core": "10.60.0",
+                "@sentry/opentelemetry": "10.60.0",
                 "import-in-the-middle": "^3.0.0"
             },
             "engines": {
@@ -6685,8 +5764,7 @@
                 "@opentelemetry/core": "^1.30.1 || ^2.1.0",
                 "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
                 "@opentelemetry/instrumentation": ">=0.57.1 <1",
-                "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-                "@opentelemetry/semantic-conventions": "^1.39.0"
+                "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
             },
             "peerDependenciesMeta": {
                 "@opentelemetry/api": {
@@ -6703,19 +5781,31 @@
                 },
                 "@opentelemetry/sdk-trace-base": {
                     "optional": true
-                },
-                "@opentelemetry/semantic-conventions": {
-                    "optional": true
                 }
             }
         },
-        "node_modules/@sentry/opentelemetry": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.55.0.tgz",
-            "integrity": "sha512-0+YrNmVNrttki4rWP4DW+UTt5MziepwDLNBde39tgc3cGCcy5fLSdDfhb4JfTaE5TXt4kd5XrkgvS/sDgm3RZg==",
+        "node_modules/@sentry/node-cpu-profiler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@sentry/node-cpu-profiler/-/node-cpu-profiler-2.4.2.tgz",
+            "integrity": "sha512-E6q+eE/sTpiofzW9jFKAx6ZQaDAoZDnsaLA/nRlkiK+K2X4k+hSyKhhLfw8PJlejB8edk7uxJF57r5JoRnyaPA==",
+            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@sentry/core": "10.55.0"
+                "detect-libc": "^2.0.3",
+                "node-abi": "^3.73.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/opentelemetry": {
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.60.0.tgz",
+            "integrity": "sha512-gl+2NVH+9RmTu7pd9kV1tKif+Th+p9tmnXR1l3Sb3Wqo1ir5FaNMKrloWEKMXjnepii9EJUrEHdSC+i8NoexxQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/conventions": "^0.12.0",
+                "@sentry/core": "10.60.0"
             },
             "engines": {
                 "node": ">=18"
@@ -6723,19 +5813,18 @@
             "peerDependencies": {
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/core": "^1.30.1 || ^2.1.0",
-                "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-                "@opentelemetry/semantic-conventions": "^1.39.0"
+                "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
             }
         },
         "node_modules/@sentry/profiling-node": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.55.0.tgz",
-            "integrity": "sha512-mraOBgrpMM5FcCaodWi59NX6f7CB60r+FXCLQXn7/+JgQ4MC8gTU953u0xOG82nBdeQ5x9rdY+vnMnbzO85MHQ==",
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.60.0.tgz",
+            "integrity": "sha512-6sEBQNdP8N20KjS12X0wr3+omxg4gMGNgyCUQ4z8JrywN8nC2DaIujZC0ps8oC6ncIoB7J8om5+mjRITZMwP6A==",
             "license": "MIT",
             "dependencies": {
-                "@sentry-internal/node-cpu-profiler": "^2.4.0",
-                "@sentry/core": "10.55.0",
-                "@sentry/node": "10.55.0"
+                "@sentry/core": "10.60.0",
+                "@sentry/node": "10.60.0",
+                "@sentry/node-cpu-profiler": "^2.4.2"
             },
             "bin": {
                 "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
@@ -6745,13 +5834,13 @@
             }
         },
         "node_modules/@sentry/react": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.55.0.tgz",
-            "integrity": "sha512-cf6wI0W1FdrL/7d5FTHXUdTN5k5uRZ9AQu5QZxUujnxWN+DBxUWtow1HDD1zTEonQsCFyYuhXVu3w+qmBBW11A==",
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.60.0.tgz",
+            "integrity": "sha512-ALRIDOj7T1Vk9t9IyI12Tq2t3MKoV2F/mKn140AiUBk3WzQhq2gXQUFpcsaDYA2FBsrYoYc6qdqrny6mMbA0Xg==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/browser": "10.55.0",
-                "@sentry/core": "10.55.0"
+                "@sentry/browser": "10.60.0",
+                "@sentry/core": "10.60.0"
             },
             "engines": {
                 "node": ">=18"
@@ -6761,20 +5850,19 @@
             }
         },
         "node_modules/@sentry/react-router": {
-            "version": "10.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry/react-router/-/react-router-10.55.0.tgz",
-            "integrity": "sha512-oGjtkbYxKQ/JfT6O7LgVp0Gw1MHouAMPoksBBTyPFP0Q7qXqY1I7PEU8sNEgodzhKU0qJlsMqsIXVVE6PypJMg==",
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/react-router/-/react-router-10.60.0.tgz",
+            "integrity": "sha512-cqVuuBFhROnAWuKGodhs480reLv1TSo5jjAjgYBDbK8g2q35pcW9R/9UIYk0t6gXYG81CY90pV5LDbOOzgGA0w==",
             "license": "MIT",
             "dependencies": {
                 "@opentelemetry/api": "^1.9.1",
-                "@opentelemetry/core": "^2.6.1",
                 "@opentelemetry/instrumentation": "^0.214.0",
-                "@opentelemetry/semantic-conventions": "^1.40.0",
-                "@sentry/browser": "10.55.0",
+                "@sentry/browser": "10.60.0",
                 "@sentry/cli": "^2.58.6",
-                "@sentry/core": "10.55.0",
-                "@sentry/node": "10.55.0",
-                "@sentry/react": "10.55.0",
+                "@sentry/conventions": "^0.12.0",
+                "@sentry/core": "10.60.0",
+                "@sentry/node": "10.60.0",
+                "@sentry/react": "10.60.0",
                 "@sentry/vite-plugin": "^5.3.0",
                 "glob": "^13.0.6"
             },
@@ -6865,6 +5953,32 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/@sentry/replay": {
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.60.0.tgz",
+            "integrity": "sha512-j+w774BP1p+v/ga1hJAJSn0cXgTiB2VWwQCAxukF7AEXscny/OCXzTTsaPxdovw9kDHI641vKV+/yixLV2nKIQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/browser-utils": "10.60.0",
+                "@sentry/core": "10.60.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/replay-canvas": {
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.60.0.tgz",
+            "integrity": "sha512-mYyQRJbhRRaqUkRvkJZyqt9AWdomh4108LOAph1YJvV1jW7tKYPPFNAUveJd7YkYCyhUOtekN0DKNJveK802qA==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "10.60.0",
+                "@sentry/replay": "10.60.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@sentry/rollup-plugin": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/@sentry/rollup-plugin/-/rollup-plugin-5.3.0.tgz",
@@ -6884,6 +5998,23 @@
                 "rollup": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@sentry/server-utils": {
+            "version": "10.60.0",
+            "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.60.0.tgz",
+            "integrity": "sha512-SX+MzWM3nz5ttKT48rlfktm0ERyIpDLma+b6pYeWgW2oFHKcpIu0g0qMGJrZs4lKM3MlgV7IqLa4texMqTp9kQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@apm-js-collab/code-transformer": "^0.15.0",
+                "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
+                "@apm-js-collab/tracing-hooks": "^0.10.0",
+                "@sentry/conventions": "^0.12.0",
+                "@sentry/core": "10.60.0",
+                "magic-string": "~0.30.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@sentry/vite-plugin": {
@@ -6926,6 +6057,86 @@
                 "@sinonjs/commons": "^3.0.1"
             }
         },
+        "node_modules/@solid-primitives/event-listener": {
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@solid-primitives/event-listener/-/event-listener-2.4.5.tgz",
+            "integrity": "sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@solid-primitives/utils": "^6.4.0"
+            },
+            "peerDependencies": {
+                "solid-js": "^1.6.12"
+            }
+        },
+        "node_modules/@solid-primitives/keyboard": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@solid-primitives/keyboard/-/keyboard-1.3.5.tgz",
+            "integrity": "sha512-sav+l+PL+74z3yaftVs7qd8c2SXkqzuxPOVibUe5wYMt+U5Hxp3V3XCPgBPN2I6cANjvoFtz0NiU8uHVLdi9FQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@solid-primitives/event-listener": "^2.4.5",
+                "@solid-primitives/rootless": "^1.5.3",
+                "@solid-primitives/utils": "^6.4.0"
+            },
+            "peerDependencies": {
+                "solid-js": "^1.6.12"
+            }
+        },
+        "node_modules/@solid-primitives/resize-observer": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@solid-primitives/resize-observer/-/resize-observer-2.1.5.tgz",
+            "integrity": "sha512-AiyTknKcNBaKHbcSMuxtSNM8FjIuiSuFyFghdD0TcCMU9hKi9EmsC5pjfjDwxE+5EueB1a+T/34PLRI5vbBbKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@solid-primitives/event-listener": "^2.4.5",
+                "@solid-primitives/rootless": "^1.5.3",
+                "@solid-primitives/static-store": "^0.1.3",
+                "@solid-primitives/utils": "^6.4.0"
+            },
+            "peerDependencies": {
+                "solid-js": "^1.6.12"
+            }
+        },
+        "node_modules/@solid-primitives/rootless": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@solid-primitives/rootless/-/rootless-1.5.3.tgz",
+            "integrity": "sha512-N8cIDAHbWcLahNRLr0knAAQvXyEdEMoAZvIMZKmhNb1mlx9e2UOv9BRD5YNwQUJwbNoYVhhLwFOEOcVXFx0HqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@solid-primitives/utils": "^6.4.0"
+            },
+            "peerDependencies": {
+                "solid-js": "^1.6.12"
+            }
+        },
+        "node_modules/@solid-primitives/static-store": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@solid-primitives/static-store/-/static-store-0.1.3.tgz",
+            "integrity": "sha512-uxez7SXnr5GiRnzqO2IEDjOJRIXaG+0LZLBizmUA1FwSi+hrpuMzVBwyk70m4prcl8X6FDDXUl9O8hSq8wHbBQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@solid-primitives/utils": "^6.4.0"
+            },
+            "peerDependencies": {
+                "solid-js": "^1.6.12"
+            }
+        },
+        "node_modules/@solid-primitives/utils": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@solid-primitives/utils/-/utils-6.4.0.tgz",
+            "integrity": "sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "solid-js": "^1.6.12"
+            }
+        },
         "node_modules/@tabler/icons": {
             "version": "3.44.0",
             "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.44.0.tgz",
@@ -6953,44 +6164,49 @@
             }
         },
         "node_modules/@tailwindcss/node": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.0.12.tgz",
-            "integrity": "sha512-a6J11K1Ztdln9OrGfoM75/hChYPcHYGNYimqciMrvKXRmmPaS8XZTHhdvb5a3glz4Kd4ZxE1MnuFE2c0fGGmtg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+            "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "enhanced-resolve": "^5.18.1",
-                "jiti": "^2.4.2",
-                "tailwindcss": "4.0.12"
+                "@jridgewell/remapping": "^2.3.5",
+                "enhanced-resolve": "5.21.6",
+                "jiti": "^2.7.0",
+                "lightningcss": "1.32.0",
+                "magic-string": "^0.30.21",
+                "source-map-js": "^1.2.1",
+                "tailwindcss": "4.3.1"
             }
         },
         "node_modules/@tailwindcss/oxide": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.12.tgz",
-            "integrity": "sha512-DWb+myvJB9xJwelwT9GHaMc1qJj6MDXRDR0CS+T8IdkejAtu8ctJAgV4r1drQJLPeS7mNwq2UHW2GWrudTf63A==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+            "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             },
             "optionalDependencies": {
-                "@tailwindcss/oxide-android-arm64": "4.0.12",
-                "@tailwindcss/oxide-darwin-arm64": "4.0.12",
-                "@tailwindcss/oxide-darwin-x64": "4.0.12",
-                "@tailwindcss/oxide-freebsd-x64": "4.0.12",
-                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.12",
-                "@tailwindcss/oxide-linux-arm64-gnu": "4.0.12",
-                "@tailwindcss/oxide-linux-arm64-musl": "4.0.12",
-                "@tailwindcss/oxide-linux-x64-gnu": "4.0.12",
-                "@tailwindcss/oxide-linux-x64-musl": "4.0.12",
-                "@tailwindcss/oxide-win32-arm64-msvc": "4.0.12",
-                "@tailwindcss/oxide-win32-x64-msvc": "4.0.12"
+                "@tailwindcss/oxide-android-arm64": "4.3.1",
+                "@tailwindcss/oxide-darwin-arm64": "4.3.1",
+                "@tailwindcss/oxide-darwin-x64": "4.3.1",
+                "@tailwindcss/oxide-freebsd-x64": "4.3.1",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+                "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+                "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
             }
         },
         "node_modules/@tailwindcss/oxide-android-arm64": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.12.tgz",
-            "integrity": "sha512-dAXCaemu3mHLXcA5GwGlQynX8n7tTdvn5i1zAxRvZ5iC9fWLl5bGnjZnzrQqT7ttxCvRwdVf3IHUnMVdDBO/kQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+            "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
             "cpu": [
                 "arm64"
             ],
@@ -7001,13 +6217,13 @@
                 "android"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-arm64": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.12.tgz",
-            "integrity": "sha512-vPNI+TpJQ7sizselDXIJdYkx9Cu6JBdtmRWujw9pVIxW8uz3O2PjgGGzL/7A0sXI8XDjSyRChrUnEW9rQygmJQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+            "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
             "cpu": [
                 "arm64"
             ],
@@ -7018,13 +6234,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-x64": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.12.tgz",
-            "integrity": "sha512-RL/9jM41Fdq4Efr35C5wgLx98BirnrfwuD+zgMFK6Ir68HeOSqBhW9jsEeC7Y/JcGyPd3MEoJVIU4fAb7YLg7A==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+            "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
             "cpu": [
                 "x64"
             ],
@@ -7035,13 +6251,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-freebsd-x64": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.12.tgz",
-            "integrity": "sha512-7WzWiax+LguJcMEimY0Q4sBLlFXu1tYxVka3+G2M9KmU/3m84J3jAIV4KZWnockbHsbb2XgrEjtlJKVwHQCoRA==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+            "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
             "cpu": [
                 "x64"
             ],
@@ -7052,13 +6268,13 @@
                 "freebsd"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.12.tgz",
-            "integrity": "sha512-X9LRC7jjE1QlfIaBbXjY0PGeQP87lz5mEfLSVs2J1yRc9PSg1tEPS9NBqY4BU9v5toZgJgzKeaNltORyTs22TQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+            "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
             "cpu": [
                 "arm"
             ],
@@ -7069,81 +6285,123 @@
                 "linux"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.12.tgz",
-            "integrity": "sha512-i24IFNq2402zfDdoWKypXz0ZNS2G4NKaA82tgBlE2OhHIE+4mg2JDb5wVfyP6R+MCm5grgXvurcIcKWvo44QiQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+            "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.12.tgz",
-            "integrity": "sha512-LmOdshJBfAGIBG0DdBWhI0n5LTMurnGGJCHcsm9F//ISfsHtCnnYIKgYQui5oOz1SUCkqsMGfkAzWyNKZqbGNw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+            "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.12.tgz",
-            "integrity": "sha512-OSK667qZRH30ep8RiHbZDQfqkXjnzKxdn0oRwWzgCO8CoTxV+MvIkd0BWdQbYtYuM1wrakARV/Hwp0eA/qzdbw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+            "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.12.tgz",
-            "integrity": "sha512-uylhWq6OWQ8krV8Jk+v0H/3AZKJW6xYMgNMyNnUbbYXWi7hIVdxRKNUB5UvrlC3RxtgsK5EAV2i1CWTRsNcAnA==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+            "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+            "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+            "bundleDependencies": [
+                "@napi-rs/wasm-runtime",
+                "@emnapi/core",
+                "@emnapi/runtime",
+                "@tybys/wasm-util",
+                "@emnapi/wasi-threads",
+                "tslib"
+            ],
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.10.0",
+                "@emnapi/runtime": "^1.10.0",
+                "@emnapi/wasi-threads": "^1.2.1",
+                "@napi-rs/wasm-runtime": "^1.1.4",
+                "@tybys/wasm-util": "^0.10.2",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.0.12.tgz",
-            "integrity": "sha512-XDLnhMoXZEEOir1LK43/gHHwK84V1GlV8+pAncUAIN2wloeD+nNciI9WRIY/BeFTqES22DhTIGoilSO39xDb2g==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+            "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
             "cpu": [
                 "arm64"
             ],
@@ -7154,13 +6412,13 @@
                 "win32"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.12.tgz",
-            "integrity": "sha512-I/BbjCLpKDQucvtn6rFuYLst1nfFwSMYyPzkx/095RE+tuzk5+fwXuzQh7T3fIBTcbn82qH/sFka7yPGA50tLw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+            "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
             "cpu": [
                 "x64"
             ],
@@ -7171,23 +6429,213 @@
                 "win32"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/vite": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.0.12.tgz",
-            "integrity": "sha512-JM3gp601UJiryIZ9R2bSqalzcOy15RCybQ1Q+BJqDEwVyo4LkWKeqQAcrpHapWXY31OJFTuOUVBFDWMhzHm2Bg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
+            "integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@tailwindcss/node": "4.0.12",
-                "@tailwindcss/oxide": "4.0.12",
-                "lightningcss": "^1.29.1",
-                "tailwindcss": "4.0.12"
+                "@tailwindcss/node": "4.3.1",
+                "@tailwindcss/oxide": "4.3.1",
+                "tailwindcss": "4.3.1"
             },
             "peerDependencies": {
-                "vite": "^5.2.0 || ^6"
+                "vite": "^5.2.0 || ^6 || ^7 || ^8"
+            }
+        },
+        "node_modules/@tanstack/devtools": {
+            "version": "0.10.14",
+            "resolved": "https://registry.npmjs.org/@tanstack/devtools/-/devtools-0.10.14.tgz",
+            "integrity": "sha512-bg1e0PyjmMMsc9VSOGb9etu15CpFdAwlQ5DD2xS6N93iTPgCPWXiZQFZygrEDoKnnx1x7BM6QTaiukizaejgSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@solid-primitives/event-listener": "^2.4.3",
+                "@solid-primitives/keyboard": "^1.3.3",
+                "@solid-primitives/resize-observer": "^2.1.3",
+                "@tanstack/devtools-client": "0.0.6",
+                "@tanstack/devtools-event-bus": "0.4.1",
+                "@tanstack/devtools-ui": "0.5.0",
+                "clsx": "^2.1.1",
+                "goober": "^2.1.16",
+                "solid-js": "^1.9.9"
+            },
+            "bin": {
+                "intent": "bin/intent.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "solid-js": ">=1.9.7"
+            }
+        },
+        "node_modules/@tanstack/devtools-client": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/@tanstack/devtools-client/-/devtools-client-0.0.5.tgz",
+            "integrity": "sha512-hsNDE3iu4frt9cC2ppn1mNRnLKo2uc1/1hXAyY9z4UYb+o40M2clFAhiFoo4HngjfGJDV3x18KVVIq7W4Un+zA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/devtools-event-client": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/devtools-event-bus": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-bus/-/devtools-event-bus-0.4.0.tgz",
+            "integrity": "sha512-1t+/csFuDzi+miDxAOh6Xv7VDE80gJEItkTcAZLjV5MRulbO/W8ocjHLI2Do/p2r2/FBU0eKCRTpdqvXaYoHpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ws": "^8.18.3"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/devtools-event-client": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-client/-/devtools-event-client-0.4.4.tgz",
+            "integrity": "sha512-6T5Yop/793YI+H+5J8Hsyj4kCih9sl4t3ElLgKioW5hk3ocn+ZdSJ94tT7vL7uabxSugWYBZlOTMPzEw2puvQw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "intent": "bin/intent.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/devtools-ui": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/devtools-ui/-/devtools-ui-0.5.0.tgz",
+            "integrity": "sha512-nNZ14054n31fWB61jtWhZYLRdQ3yceCE3G/RINoINUB0RqIGZAIm9DnEDwOTAOfqt4/a/D8vNk8pJu6RQUp74g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "clsx": "^2.1.1",
+                "dayjs": "^1.11.19",
+                "goober": "^2.1.16",
+                "solid-js": "^1.9.9"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "solid-js": ">=1.9.7"
+            }
+        },
+        "node_modules/@tanstack/devtools-vite": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@tanstack/devtools-vite/-/devtools-vite-0.4.1.tgz",
+            "integrity": "sha512-PkMOomcWnl/pUkCqIjqL/csjPHtkMVBirDpJVOZR7XJZDxo5CuD7B+3KsujFCF4Dsn6QYlae97gCZvxi/CB76Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.28.4",
+                "@babel/generator": "^7.28.3",
+                "@babel/parser": "^7.28.4",
+                "@babel/traverse": "^7.28.4",
+                "@babel/types": "^7.28.4",
+                "@tanstack/devtools-client": "0.0.5",
+                "@tanstack/devtools-event-bus": "0.4.0",
+                "chalk": "^5.6.2",
+                "launch-editor": "^2.11.1",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "vite": "^6.0.0 || ^7.0.0"
+            }
+        },
+        "node_modules/@tanstack/devtools/node_modules/@tanstack/devtools-client": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@tanstack/devtools-client/-/devtools-client-0.0.6.tgz",
+            "integrity": "sha512-f85ZJXJnDIFOoykG/BFIixuAevJovCvJF391LPs6YjBAPhGYC50NWlx1y4iF/UmK5/cCMx+/JqI5SBOz7FanQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/devtools-event-client": "^0.4.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/devtools/node_modules/@tanstack/devtools-event-bus": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-bus/-/devtools-event-bus-0.4.1.tgz",
+            "integrity": "sha512-cNnJ89Q021Zf883rlbBTfsaxTfi2r73/qejGtyTa7ksErF3hyDyAq1aTbo5crK9dAL7zSHh9viKY1BtMls1QOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ws": "^8.18.3"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/react-devtools": {
+            "version": "0.9.13",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-devtools/-/react-devtools-0.9.13.tgz",
+            "integrity": "sha512-O9YXTEe2dlnw2pPNKFZ4Wk7zC4qrDvc0SAALKfMVedeZ2Dyd0LEJUabYS6GPm+DmnrBhc7nJx6Zqc9aDjFrj4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/devtools": "0.10.14"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "@types/react": ">=16.8",
+                "@types/react-dom": ">=16.8",
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
             }
         },
         "node_modules/@testing-library/dom": {
@@ -7300,10 +6748,9 @@
             }
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-            "dev": true,
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -7477,13 +6924,6 @@
                 "undici-types": "~6.21.0"
             }
         },
-        "node_modules/@types/parse-json": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-            "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-            "devOptional": true,
-            "license": "MIT"
-        },
         "node_modules/@types/react": {
             "version": "19.2.15",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
@@ -7501,16 +6941,6 @@
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
-            }
-        },
-        "node_modules/@types/react-reconciler": {
-            "version": "0.28.9",
-            "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
-            "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "*"
             }
         },
         "node_modules/@types/retry": {
@@ -7946,33 +7376,23 @@
                 "ts-morph": "12.0.0"
             }
         },
-        "node_modules/abbrev": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
         "node_modules/accepts": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
             "license": "MIT",
             "dependencies": {
-                "mime-types": "~2.1.34",
-                "negotiator": "0.6.3"
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/accepts/node_modules/negotiator": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -8054,7 +7474,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
             "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -8067,7 +7486,6 @@
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
             "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -8104,9 +7522,9 @@
             }
         },
         "node_modules/appwrite": {
-            "version": "25.2.0",
-            "resolved": "https://registry.npmjs.org/appwrite/-/appwrite-25.2.0.tgz",
-            "integrity": "sha512-N3aKpS/bnnk93Hau9+6ybyJ8VHoBD0F8a6vkaUD/i7eyHVc0+2UK9e16r+GDTiMuM7RoQ3nB/rb3gCvzpuLpKA==",
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/appwrite/-/appwrite-26.0.0.tgz",
+            "integrity": "sha512-8YTr/Cq5zhPvGQ91Ocmm+qjgxKAFkYFp1OvJFnrTPN3c2ChwUxNmLqQ9bGTUKH7+j8BDFs1dEAFMZQQEpACu1A==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "json-bigint": "1.0.0"
@@ -8129,19 +7547,6 @@
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/aria-hidden": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
-            "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/aria-query": {
@@ -8170,12 +7575,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-            "license": "MIT"
         },
         "node_modules/array-includes": {
             "version": "3.1.9",
@@ -8307,6 +7706,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/astring": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+            "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+            "license": "MIT",
+            "bin": {
+                "astring": "bin/astring"
+            }
+        },
         "node_modules/async-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -8334,9 +7742,9 @@
             }
         },
         "node_modules/babel-dead-code-elimination": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/babel-dead-code-elimination/-/babel-dead-code-elimination-1.0.9.tgz",
-            "integrity": "sha512-JLIhax/xullfInZjtu13UJjaLHDeTzt3vOeomaSUdO/nAMEL/pWC/laKrSvWylXMnVWyL5bpmG9njqBZlUQOdg==",
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/babel-dead-code-elimination/-/babel-dead-code-elimination-1.0.12.tgz",
+            "integrity": "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.23.7",
@@ -8431,22 +7839,6 @@
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/babel-plugin-macros": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-            "devOptional": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "cosmiconfig": "^7.0.0",
-                "resolve": "^1.19.0"
-            },
-            "engines": {
-                "node": ">=10",
-                "npm": ">=6"
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
@@ -8636,21 +8028,6 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "license": "MIT"
         },
-        "node_modules/beautify": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/beautify/-/beautify-0.0.8.tgz",
-            "integrity": "sha512-1iF6Ey2qxDkm6bPgKcoXUmwFDpoRi5IgwefQDDQBRLxlZAAYwcULoQ2IdBArXZuSsuL7AT+KvZI9xZVLeUZPRg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cssbeautify": "^0.3.1",
-                "html": "^1.0.0",
-                "js-beautify": "^1.6.4"
-            },
-            "bin": {
-                "beautify": "bin/beautify.js"
-            }
-        },
         "node_modules/bignumber.js": {
             "version": "9.1.2",
             "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
@@ -8660,63 +8037,47 @@
                 "node": "*"
             }
         },
-        "node_modules/bippy": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/bippy/-/bippy-0.3.8.tgz",
-            "integrity": "sha512-0ou8fJWxUXK/+eRjUz5unbtX8Mrn0OYRs6QQwwUJtU6hsFDTSmSeI1fJC/2nrPA4G6GWcxwT+O6TbHyGhl4fEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/react-reconciler": "^0.28.9"
-            },
-            "peerDependencies": {
-                "react": ">=17.0.1"
-            }
-        },
         "node_modules/body-parser": {
-            "version": "1.20.3",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
             "license": "MIT",
             "dependencies": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.5",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.13.0",
-                "raw-body": "2.5.2",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
+                "bytes": "^3.1.2",
+                "content-type": "^2.0.0",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
+                "on-finished": "^2.4.1",
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
             },
             "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/body-parser/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/body-parser/node_modules/ms": {
+        "node_modules/body-parser/node_modules/content-type": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
         },
         "node_modules/brace-expansion": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
             "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -8796,15 +8157,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/cac": {
-            "version": "6.7.14",
-            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/calendar-link": {
@@ -9005,15 +8357,15 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "license": "MIT",
             "dependencies": {
-                "readdirp": "^4.0.1"
+                "readdirp": "^5.0.0"
             },
             "engines": {
-                "node": ">= 14.16.0"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
@@ -9271,16 +8623,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/commander": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/compressible": {
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -9332,49 +8674,23 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
         },
-        "node_modules/concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
-            "engines": [
-                "node >= 0.8"
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-            }
-        },
         "node_modules/confbox": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
             "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
             "license": "MIT"
         },
-        "node_modules/config-chain": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
-            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
-            }
-        },
         "node_modules/content-disposition": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
             "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "5.2.1"
-            },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/content-type": {
@@ -9405,11 +8721,20 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/cookie-signature": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+        "node_modules/cookie-es": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+            "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
             "license": "MIT"
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
         },
         "node_modules/core-js-compat": {
             "version": "3.49.0",
@@ -9434,40 +8759,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/cosmiconfig": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-            "devOptional": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/parse-json": "^4.0.0",
-                "import-fresh": "^3.2.1",
-                "parse-json": "^5.0.0",
-                "path-type": "^4.0.0",
-                "yaml": "^1.10.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/cosmiconfig/node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "devOptional": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/cross-env": {
@@ -9516,18 +8807,6 @@
             "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/cssbeautify": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
-            "integrity": "sha512-ljnSOCOiMbklF+dwPbpooyB78foId02vUrTDogWzu6ca2DCNB7Kc/BHEGBnYOlUYtwXvSW0mWTwaiO2pwFIoRg==",
-            "dev": true,
-            "bin": {
-                "cssbeautify": "bin/cssbeautify"
-            },
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/cssesc": {
             "version": "3.0.0",
@@ -9814,17 +9093,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/date-fns": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-            "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/kossnocorp"
-            }
-        },
         "node_modules/dayjs": {
             "version": "1.11.21",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
@@ -9869,9 +9137,9 @@
             }
         },
         "node_modules/dedent": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
-            "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+            "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
             "license": "MIT",
             "peerDependencies": {
                 "babel-plugin-macros": "^3.1.0"
@@ -9953,16 +9221,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/destroy": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
         "node_modules/detect-libc": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -9999,16 +9257,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
             }
         },
         "node_modules/doctrine": {
@@ -10081,7 +9329,6 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/ecdsa-sig-formatter": {
@@ -10091,41 +9338,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/editorconfig": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
-            "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@one-ini/wasm": "0.1.1",
-                "commander": "^10.0.0",
-                "minimatch": "9.0.1",
-                "semver": "^7.5.3"
-            },
-            "bin": {
-                "editorconfig": "bin/editorconfig"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/editorconfig/node_modules/minimatch": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-            "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/ee-first": {
@@ -10194,7 +9406,6 @@
             "version": "9.2.2",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/encodeurl": {
@@ -10207,14 +9418,14 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-            "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+            "version": "5.21.6",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+            "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
+                "tapable": "^2.3.3"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -10373,9 +9584,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
@@ -10435,47 +9646,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/esbuild": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.12",
-                "@esbuild/android-arm": "0.25.12",
-                "@esbuild/android-arm64": "0.25.12",
-                "@esbuild/android-x64": "0.25.12",
-                "@esbuild/darwin-arm64": "0.25.12",
-                "@esbuild/darwin-x64": "0.25.12",
-                "@esbuild/freebsd-arm64": "0.25.12",
-                "@esbuild/freebsd-x64": "0.25.12",
-                "@esbuild/linux-arm": "0.25.12",
-                "@esbuild/linux-arm64": "0.25.12",
-                "@esbuild/linux-ia32": "0.25.12",
-                "@esbuild/linux-loong64": "0.25.12",
-                "@esbuild/linux-mips64el": "0.25.12",
-                "@esbuild/linux-ppc64": "0.25.12",
-                "@esbuild/linux-riscv64": "0.25.12",
-                "@esbuild/linux-s390x": "0.25.12",
-                "@esbuild/linux-x64": "0.25.12",
-                "@esbuild/netbsd-arm64": "0.25.12",
-                "@esbuild/netbsd-x64": "0.25.12",
-                "@esbuild/openbsd-arm64": "0.25.12",
-                "@esbuild/openbsd-x64": "0.25.12",
-                "@esbuild/openharmony-arm64": "0.25.12",
-                "@esbuild/sunos-x64": "0.25.12",
-                "@esbuild/win32-arm64": "0.25.12",
-                "@esbuild/win32-ia32": "0.25.12",
-                "@esbuild/win32-x64": "0.25.12"
             }
         },
         "node_modules/escalade": {
@@ -10938,7 +10108,6 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
             "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -10964,7 +10133,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -11054,12 +10222,12 @@
             "license": "ISC"
         },
         "node_modules/exit-hook": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
-            "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-5.1.0.tgz",
+            "integrity": "sha512-INjr2xyxHo7bhAqf5ong++GZPPnpcuBcaXUKt03yf7Fie9yWD7FapL4teOU0+awQazGs5ucBh7xWs/AD+6nhog==",
             "license": "MIT",
             "engines": {
-                "node": ">=6"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -11094,45 +10262,42 @@
             }
         },
         "node_modules/express": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
             "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.3",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.7.1",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.3.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.13.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.19.0",
-                "serve-static": "1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
             },
             "engines": {
-                "node": ">= 0.10.0"
+                "node": ">= 18"
             },
             "funding": {
                 "type": "opencollective",
@@ -11140,28 +10305,13 @@
             }
         },
         "node_modules/express/node_modules/cookie": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/express/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/express/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "license": "MIT"
         },
         "node_modules/exsolve": {
             "version": "1.0.8",
@@ -11308,44 +10458,25 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
             "license": "MIT",
             "dependencies": {
-                "debug": "2.6.9",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "statuses": "2.0.1",
-                "unpipe": "~1.0.0"
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
-        },
-        "node_modules/finalhandler/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/finalhandler/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "license": "MIT"
-        },
-        "node_modules/find-root": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/find-up": {
             "version": "4.1.0",
@@ -11438,7 +10569,6 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
             "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "cross-spawn": "^7.0.6",
@@ -11473,14 +10603,14 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "12.4.11",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.4.11.tgz",
-            "integrity": "sha512-MHeZlgzo9DnQ6+TFgRqJiOk4vWwsDcXFtxeXlVawVs1nwgcZW3966foGIgkIiIrBSPHB9RlbqspAxiYWosFT9g==",
+            "version": "12.41.0",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.41.0.tgz",
+            "integrity": "sha512-OHAMNiCEON1RDBlRGuulsN5AD8ptMjvk5QWfFmYmBLPZ3zFGIJe60kQucQQf4cez1OzQmjYBWDY+dYfISkUdqg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "motion-dom": "^12.4.11",
-                "motion-utils": "^12.4.10",
+                "motion-dom": "^12.41.0",
+                "motion-utils": "^12.39.0",
                 "tslib": "^2.4.0"
             },
             "peerDependencies": {
@@ -11501,12 +10631,12 @@
             }
         },
         "node_modules/fresh": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
         "node_modules/fs.realpath": {
@@ -11571,33 +10701,49 @@
             }
         },
         "node_modules/gaxios": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
-            "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+            "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "extend": "^3.0.2",
                 "https-proxy-agent": "^7.0.1",
-                "is-stream": "^2.0.0",
-                "node-fetch": "^2.6.9",
-                "uuid": "^9.0.1"
+                "node-fetch": "^3.3.2"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
+            }
+        },
+        "node_modules/gaxios/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "license": "MIT",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/gcp-metadata": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-            "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+            "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "gaxios": "^6.1.1",
-                "google-logging-utils": "^0.0.2",
+                "gaxios": "^7.0.0",
+                "google-logging-utils": "^1.0.0",
                 "json-bigint": "^1.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             }
         },
         "node_modules/generator-function": {
@@ -11685,12 +10831,12 @@
             }
         },
         "node_modules/get-port": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-            "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+            "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
             "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -11745,7 +10891,6 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
@@ -11804,67 +10949,134 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/globrex": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-            "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+        "node_modules/goober": {
+            "version": "2.1.19",
+            "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
+            "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peerDependencies": {
+                "csstype": "^3.0.10"
+            }
         },
         "node_modules/google-auth-library": {
-            "version": "9.15.1",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-            "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+            "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
-                "gaxios": "^6.1.1",
-                "gcp-metadata": "^6.1.0",
-                "gtoken": "^7.0.0",
+                "gaxios": "^7.1.4",
+                "gcp-metadata": "8.1.2",
+                "google-logging-utils": "1.1.3",
                 "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             }
         },
         "node_modules/google-logging-utils": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-            "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+            "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
             }
         },
         "node_modules/googleapis": {
-            "version": "146.0.0",
-            "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-146.0.0.tgz",
-            "integrity": "sha512-NewqvhnBZOJsugCAOo636O0BGE/xY7Cg/v8Rjm1+5LkJCjcqAzLleJ6igd5vrRExJLSKrY9uHy9iKE7r0PrfhQ==",
+            "version": "173.0.0",
+            "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-173.0.0.tgz",
+            "integrity": "sha512-xEJJYLZ4qeenVyfzispNfRjCe9bsv7CzBv5zYFLvScOze9snJ8S9W6hjQ729CWPQt5mvn/JrcRaCHzQiukt0ng==",
             "license": "Apache-2.0",
             "dependencies": {
-                "google-auth-library": "^9.0.0",
-                "googleapis-common": "^7.0.0"
+                "google-auth-library": "^10.2.0",
+                "googleapis-common": "^8.0.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/googleapis-common": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
-            "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.2.tgz",
+            "integrity": "sha512-5MXeQzIZaqCH7B+HJWqhQm946VARpZep6acbWSr/fcgF2cQANq7allgX+i/G0EqF0WyUxB277gtWMzRYHMl9tg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "extend": "^3.0.2",
-                "gaxios": "^6.0.3",
-                "google-auth-library": "^9.7.0",
+                "gaxios": "7.1.3",
+                "google-auth-library": "10.5.0",
+                "google-logging-utils": "1.1.3",
                 "qs": "^6.7.0",
-                "url-template": "^2.0.8",
-                "uuid": "^9.0.0"
+                "url-template": "^2.0.8"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/googleapis-common/node_modules/gaxios": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+            "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "node-fetch": "^3.3.2",
+                "rimraf": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/googleapis-common/node_modules/google-auth-library": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+            "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "base64-js": "^1.3.0",
+                "ecdsa-sig-formatter": "^1.0.11",
+                "gaxios": "^7.0.0",
+                "gcp-metadata": "^8.0.0",
+                "google-logging-utils": "^1.0.0",
+                "gtoken": "^8.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/googleapis-common/node_modules/gtoken": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+            "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+            "license": "MIT",
+            "dependencies": {
+                "gaxios": "^7.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/googleapis-common/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "license": "MIT",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/gopd": {
@@ -11897,6 +11109,22 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/gtoken/node_modules/gaxios": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+            "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "is-stream": "^2.0.0",
+                "node-fetch": "^2.6.9",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/has-bigints": {
@@ -12048,29 +11276,6 @@
                 "hermes-estree": "0.25.1"
             }
         },
-        "node_modules/hoist-non-react-statics": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "react-is": "^16.7.0"
-            }
-        },
-        "node_modules/html": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/html/-/html-1.0.0.tgz",
-            "integrity": "sha512-lw/7YsdKiP3kk5PnR1INY17iJuzdAtJewxr14ozKJWbbR97znovZ0mh+WEMZ8rjc3lgTK+ID/htTjuyGKB52Kw==",
-            "dev": true,
-            "license": "BSD",
-            "dependencies": {
-                "concat-stream": "^1.4.7"
-            },
-            "bin": {
-                "html": "bin/html.js"
-            }
-        },
         "node_modules/html-encoding-sniffer": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -12102,19 +11307,23 @@
             }
         },
         "node_modules/http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "license": "MIT",
             "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             },
             "engines": {
                 "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/http-parser-js": {
@@ -12177,15 +11386,19 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
             "license": "MIT",
             "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/idb": {
@@ -12224,9 +11437,9 @@
             }
         },
         "node_modules/import-in-the-middle": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
-            "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.2.0.tgz",
+            "integrity": "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "acorn": "^8.15.0",
@@ -12294,13 +11507,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
-        },
-        "node_modules/ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/inline-style-parser": {
@@ -12696,6 +11902,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
+        },
         "node_modules/is-regex": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -12865,13 +12077,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/isbot": {
             "version": "5.1.40",
             "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.40.tgz",
@@ -12980,7 +12185,6 @@
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
             "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
@@ -13926,16 +13130,6 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/jest-runner/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/jest-runner/node_modules/source-map-support": {
             "version": "0.5.13",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -14369,45 +13563,13 @@
             }
         },
         "node_modules/jiti": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-            "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "devOptional": true,
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
-            }
-        },
-        "node_modules/js-beautify": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
-            "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "config-chain": "^1.1.13",
-                "editorconfig": "^1.0.4",
-                "glob": "^10.4.2",
-                "js-cookie": "^3.0.5",
-                "nopt": "^7.2.1"
-            },
-            "bin": {
-                "css-beautify": "js/bin/css-beautify.js",
-                "html-beautify": "js/bin/html-beautify.js",
-                "js-beautify": "js/bin/js-beautify.js"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/js-cookie": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/js-tokens": {
@@ -14508,9 +13670,9 @@
             }
         },
         "node_modules/jsesc": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
@@ -14623,6 +13785,17 @@
                 "json-buffer": "3.0.1"
             }
         },
+        "node_modules/launch-editor": {
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+            "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.1.1",
+                "shell-quote": "^1.8.4"
+            }
+        },
         "node_modules/leven": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -14648,10 +13821,9 @@
             }
         },
         "node_modules/lightningcss": {
-            "version": "1.29.2",
-            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.2.tgz",
-            "integrity": "sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==",
-            "devOptional": true,
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
             "license": "MPL-2.0",
             "dependencies": {
                 "detect-libc": "^2.0.3"
@@ -14664,22 +13836,43 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "lightningcss-darwin-arm64": "1.29.2",
-                "lightningcss-darwin-x64": "1.29.2",
-                "lightningcss-freebsd-x64": "1.29.2",
-                "lightningcss-linux-arm-gnueabihf": "1.29.2",
-                "lightningcss-linux-arm64-gnu": "1.29.2",
-                "lightningcss-linux-arm64-musl": "1.29.2",
-                "lightningcss-linux-x64-gnu": "1.29.2",
-                "lightningcss-linux-x64-musl": "1.29.2",
-                "lightningcss-win32-arm64-msvc": "1.29.2",
-                "lightningcss-win32-x64-msvc": "1.29.2"
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.29.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.2.tgz",
-            "integrity": "sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
             "cpu": [
                 "arm64"
             ],
@@ -14697,9 +13890,9 @@
             }
         },
         "node_modules/lightningcss-darwin-x64": {
-            "version": "1.29.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.2.tgz",
-            "integrity": "sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
             "cpu": [
                 "x64"
             ],
@@ -14717,9 +13910,9 @@
             }
         },
         "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.29.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.2.tgz",
-            "integrity": "sha512-wDk7M2tM78Ii8ek9YjnY8MjV5f5JN2qNVO+/0BAGZRvXKtQrBC4/cn4ssQIpKIPP44YXw6gFdpUF+Ps+RGsCwg==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
             "cpu": [
                 "x64"
             ],
@@ -14737,9 +13930,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.29.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.2.tgz",
-            "integrity": "sha512-IRUrOrAF2Z+KExdExe3Rz7NSTuuJ2HvCGlMKoquK5pjvo2JY4Rybr+NrKnq0U0hZnx5AnGsuFHjGnNT14w26sg==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
             "cpu": [
                 "arm"
             ],
@@ -14757,11 +13950,14 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.29.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.2.tgz",
-            "integrity": "sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -14777,11 +13973,14 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.29.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.2.tgz",
-            "integrity": "sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -14797,11 +13996,14 @@
             }
         },
         "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.29.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.2.tgz",
-            "integrity": "sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -14817,11 +14019,14 @@
             }
         },
         "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.29.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.2.tgz",
-            "integrity": "sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -14837,9 +14042,9 @@
             }
         },
         "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.29.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.2.tgz",
-            "integrity": "sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
             "cpu": [
                 "arm64"
             ],
@@ -14857,9 +14062,9 @@
             }
         },
         "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.29.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.2.tgz",
-            "integrity": "sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
             "cpu": [
                 "x64"
             ],
@@ -15009,9 +14214,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.camelcase": {
@@ -15384,26 +14589,22 @@
             }
         },
         "node_modules/media-typer": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
-        "node_modules/memoize-one": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
-            "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/merge-descriptors": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
             "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
@@ -15424,13 +14625,13 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/methods": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-            "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-            "license": "MIT",
+        "node_modules/meriyah": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+            "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+            "license": "ISC",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/micromark": {
@@ -15900,18 +15101,6 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/mime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-            "license": "MIT",
-            "bin": {
-                "mime": "cli.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/mime-db": {
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -15922,24 +15111,19 @@
             }
         },
         "node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
             "license": "MIT",
             "dependencies": {
-                "mime-db": "1.52.0"
+                "mime-db": "^1.54.0"
             },
             "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types/node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/mimic-fn": {
@@ -15979,7 +15163,6 @@
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
             "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -16062,19 +15245,19 @@
             }
         },
         "node_modules/motion-dom": {
-            "version": "12.4.11",
-            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.4.11.tgz",
-            "integrity": "sha512-wstlyV3pktgFjqsjbXMo1NX9hQD9XTVqxQNvfc+FREAgxr3GVzgWIEKvbyyNlki3J1jmmh+et9X3aCKeqFPcxA==",
+            "version": "12.41.0",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.41.0.tgz",
+            "integrity": "sha512-Lk3J39fOGg6xNr1KRZsN6usDyBf8aP7MEbUPez1VCughHt79OrP7VGqNrPyFL0riaT7WS8t9DRw1M3BHtM/xKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "motion-utils": "^12.4.10"
+                "motion-utils": "^12.39.0"
             }
         },
         "node_modules/motion-utils": {
-            "version": "12.4.10",
-            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.4.10.tgz",
-            "integrity": "sha512-NPwZd94V013SwRf++jMrk2+HEBgPkeIE2RiOzhAuuQlqxMJPkKt/LXVh6Upl+iN8oarSGD2dlY5/bqgsYXDABA==",
+            "version": "12.39.0",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+            "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -16160,13 +15343,13 @@
             }
         },
         "node_modules/node-appwrite": {
-            "version": "25.2.0",
-            "resolved": "https://registry.npmjs.org/node-appwrite/-/node-appwrite-25.2.0.tgz",
-            "integrity": "sha512-htfGugjhkLBT7QYpBA6P0bKApH9HpsGrGoxhL0DPxuWY0JUiCamEnu9tqfqIhbdsHJiNL3yYdpzkEDddBU9msQ==",
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/node-appwrite/-/node-appwrite-26.2.0.tgz",
+            "integrity": "sha512-rRToHOuG05F5Q3BGRoJNNIcO69zrYul/V9HOTxfcMSqhdw3TwInAl7pnSnMRW7D0MOQcvaLb8iZIwE1P8TP9Cw==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "json-bigint": "1.0.0",
-                "node-fetch-native-with-agent": "1.7.2"
+                "undici": "^6.26.0"
             }
         },
         "node_modules/node-domexception": {
@@ -16238,12 +15421,6 @@
                 }
             }
         },
-        "node_modules/node-fetch-native-with-agent": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/node-fetch-native-with-agent/-/node-fetch-native-with-agent-1.7.2.tgz",
-            "integrity": "sha512-5MaOOCuJEvcckoz7/tjdx1M6OusOY6Xc5f459IaruGStWnKzlI1qpNgaAwmn4LmFYcsSlj+jBMk84wmmRxfk5g==",
-            "license": "MIT"
-        },
         "node_modules/node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -16258,22 +15435,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/nopt": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "^2.0.0"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/normalize-path": {
@@ -16437,7 +15598,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -16603,7 +15763,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-            "dev": true,
             "license": "BlueOak-1.0.0"
         },
         "node_modules/parent-module": {
@@ -16737,7 +15896,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
             "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "lru-cache": "^10.2.0",
@@ -16754,29 +15912,22 @@
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-            "license": "MIT"
-        },
-        "node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "devOptional": true,
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
             "license": "MIT",
-            "engines": {
-                "node": ">=8"
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/pathe": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -16843,12 +15994,6 @@
                 "exsolve": "^1.0.8",
                 "pathe": "^2.0.3"
             }
-        },
-        "node_modules/pkg-types/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "license": "MIT"
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
@@ -17028,6 +16173,7 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -17084,13 +16230,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -17120,13 +16259,6 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
-        },
-        "node_modules/proto-list": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/protobufjs": {
             "version": "7.5.4",
@@ -17198,12 +16330,12 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.0.6"
+                "side-channel": "^1.1.0"
             },
             "engines": {
                 "node": ">=0.6"
@@ -17248,24 +16380,24 @@
             }
         },
         "node_modules/raw-body": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
             "license": "MIT",
             "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 0.10"
             }
         },
         "node_modules/react": {
-            "version": "19.2.6",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-            "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+            "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -17303,48 +16435,30 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-        "node_modules/react-diff-viewer-continued": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/react-diff-viewer-continued/-/react-diff-viewer-continued-4.0.5.tgz",
-            "integrity": "sha512-L43gIPdhHgu1MYdip4vNqAt5s2JLICKe2/RyGUr2ohAxfhYaH1+QZ6vBO0qgo4xGBhE3jmvbOA/swq4/gdS/0g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@emotion/css": "^11.13.5",
-                "@emotion/react": "^11.14.0",
-                "classnames": "^2.5.1",
-                "diff": "^5.2.0",
-                "memoize-one": "^6.0.0"
-            },
-            "engines": {
-                "node": ">= 16"
-            },
-            "peerDependencies": {
-                "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
         "node_modules/react-dom": {
-            "version": "19.2.6",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-            "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+            "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
             "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.2.6"
+                "react": "^19.2.7"
             }
         },
         "node_modules/react-hotkeys-hook": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.6.1.tgz",
-            "integrity": "sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-5.3.2.tgz",
+            "integrity": "sha512-DDDy9xK6mbTQ6aPlQvIl0dA/a90T/AWml4Rm21JXFDLlRHalIg4/Rv3equUQYs5xPTWq+oEl6RD7mi/nBpU3Uw==",
             "dev": true,
             "license": "MIT",
+            "workspaces": [
+                "packages/*"
+            ],
             "peerDependencies": {
-                "react": ">=16.8.1",
-                "react-dom": ">=16.8.1"
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
             }
         },
         "node_modules/react-imask": {
@@ -17485,9 +16599,9 @@
             }
         },
         "node_modules/react-refresh": {
-            "version": "0.14.2",
-            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
-            "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+            "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -17541,20 +16655,19 @@
             }
         },
         "node_modules/react-router": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-            "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.0.1.tgz",
+            "integrity": "sha512-5EL/fANovVUhRK50NLS8RYfX0BxrimoKsHWUPPy8v5UEl8i6vzF7e4POo3u+AhPItDwccUAJjMfIOmydxBJmQw==",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^1.0.1",
-                "set-cookie-parser": "^2.6.0"
+                "cookie-es": "^3.1.1"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=22.22.0"
             },
             "peerDependencies": {
-                "react": ">=18",
-                "react-dom": ">=18"
+                "react": ">=19.2.7",
+                "react-dom": ">=19.2.7"
             },
             "peerDependenciesMeta": {
                 "react-dom": {
@@ -17563,40 +16676,38 @@
             }
         },
         "node_modules/react-router-devtools": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/react-router-devtools/-/react-router-devtools-1.1.10.tgz",
-            "integrity": "sha512-/Lg0doiVq/Bv547SU4ZWE2UPUaNToGQ0Rnao0tWrZVvPfgGLMQJi4TLv3CxLrXFCo5QeZh0omJ1SCGXOZmpUUw==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/react-router-devtools/-/react-router-devtools-6.2.1.tgz",
+            "integrity": "sha512-qhQg5bJvsiWQpCddehh7HUpNt/zGlxHygG3rseooky1ENDGmlNwB08w4gW4YZRzeZOPgVpgEXgw94ypBpGfpww==",
             "dev": true,
             "license": "MIT",
-            "workspaces": [
-                ".",
-                "test-apps/*"
-            ],
             "dependencies": {
-                "@babel/core": "^7.26.10",
-                "@babel/generator": "^7.26.5",
-                "@babel/parser": "^7.26.10",
-                "@babel/traverse": "^7.26.10",
-                "@babel/types": "^7.26.10",
-                "@radix-ui/react-accordion": "^1.2.2",
-                "@radix-ui/react-select": "^2.1.5",
-                "beautify": "^0.0.8",
-                "bippy": "^0.3.7",
-                "chalk": "^5.4.1",
-                "clsx": "^2.1.1",
-                "date-fns": "^4.1.0",
-                "framer-motion": "^12.0.6",
-                "react-d3-tree": "^3.6.4",
-                "react-diff-viewer-continued": "^4.0.5",
-                "react-hotkeys-hook": "^4.6.1",
-                "react-tooltip": "^5.28.0"
+                "@babel/core": "^7.28.5",
+                "@babel/generator": "^7.28.5",
+                "@babel/parser": "^7.28.5",
+                "@babel/traverse": "^7.28.5",
+                "@babel/types": "^7.28.5",
+                "@radix-ui/react-accordion": "^1.2.12",
+                "@tanstack/devtools-client": "^0.0.5",
+                "@tanstack/devtools-event-client": "^0.4.0",
+                "@tanstack/devtools-vite": "^0.4.1",
+                "@tanstack/react-devtools": "^0.9.1",
+                "chalk": "5.6.2",
+                "clsx": "2.1.1",
+                "framer-motion": "^12.23.24",
+                "goober": "^2.1.18",
+                "react-d3-tree": "^3.6.6",
+                "react-hotkeys-hook": "^5.2.1",
+                "react-tooltip": "^5.30.0"
             },
             "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "^1.9.4",
-                "@rollup/rollup-darwin-arm64": "^4.32.1",
-                "@rollup/rollup-linux-x64-gnu": "^4.32.1"
+                "@biomejs/cli-darwin-arm64": "^2.3.5",
+                "@rollup/rollup-darwin-arm64": "^4.53.2",
+                "@rollup/rollup-linux-x64-gnu": "^4.53.2"
             },
             "peerDependencies": {
+                "@types/react": ">=17",
+                "@types/react-dom": ">=17",
                 "react": ">=17",
                 "react-dom": ">=17",
                 "react-router": ">=7.0.0",
@@ -17626,9 +16737,9 @@
             }
         },
         "node_modules/react-tooltip": {
-            "version": "5.28.0",
-            "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.28.0.tgz",
-            "integrity": "sha512-R5cO3JPPXk6FRbBHMO0rI9nkUG/JKfalBSQfZedZYzmqaZQgq7GLzF8vcCWx6IhUCKg0yPqJhXIzmIO5ff15xg==",
+            "version": "5.30.1",
+            "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.30.1.tgz",
+            "integrity": "sha512-1lSPLQXuVooePxadUpmcwLgOsF1mIty7UZTJ9XnyfX4drOzStYs4JMXnazcDLguQr41W5OUZddOp9kfvArdpEQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17666,36 +16777,13 @@
                 "csstype": "^3.0.2"
             }
         },
-        "node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/readdirp": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
             "license": "MIT",
             "engines": {
-                "node": ">= 14.18.0"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "type": "individual",
@@ -17828,19 +16916,6 @@
             },
             "bin": {
                 "regjsparser": "bin/parser"
-            }
-        },
-        "node_modules/regjsparser/node_modules/jsesc": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "jsesc": "bin/jsesc"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/remark-parse": {
@@ -17996,48 +17071,68 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/rollup": {
-            "version": "4.60.4",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
-            "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
-            "license": "MIT",
+        "node_modules/rimraf": {
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+            "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+            "license": "ISC",
             "dependencies": {
-                "@types/estree": "1.0.8"
+                "glob": "^10.3.7"
             },
             "bin": {
-                "rollup": "dist/bin/rollup"
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rolldown": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+            "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.137.0",
+                "@rolldown/pluginutils": "^1.0.0"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
             },
             "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.60.4",
-                "@rollup/rollup-android-arm64": "4.60.4",
-                "@rollup/rollup-darwin-arm64": "4.60.4",
-                "@rollup/rollup-darwin-x64": "4.60.4",
-                "@rollup/rollup-freebsd-arm64": "4.60.4",
-                "@rollup/rollup-freebsd-x64": "4.60.4",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
-                "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
-                "@rollup/rollup-linux-arm64-gnu": "4.60.4",
-                "@rollup/rollup-linux-arm64-musl": "4.60.4",
-                "@rollup/rollup-linux-loong64-gnu": "4.60.4",
-                "@rollup/rollup-linux-loong64-musl": "4.60.4",
-                "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
-                "@rollup/rollup-linux-ppc64-musl": "4.60.4",
-                "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
-                "@rollup/rollup-linux-riscv64-musl": "4.60.4",
-                "@rollup/rollup-linux-s390x-gnu": "4.60.4",
-                "@rollup/rollup-linux-x64-gnu": "4.60.4",
-                "@rollup/rollup-linux-x64-musl": "4.60.4",
-                "@rollup/rollup-openbsd-x64": "4.60.4",
-                "@rollup/rollup-openharmony-arm64": "4.60.4",
-                "@rollup/rollup-win32-arm64-msvc": "4.60.4",
-                "@rollup/rollup-win32-ia32-msvc": "4.60.4",
-                "@rollup/rollup-win32-x64-gnu": "4.60.4",
-                "@rollup/rollup-win32-x64-msvc": "4.60.4",
-                "fsevents": "~2.3.2"
+                "@rolldown/binding-android-arm64": "1.1.3",
+                "@rolldown/binding-darwin-arm64": "1.1.3",
+                "@rolldown/binding-darwin-x64": "1.1.3",
+                "@rolldown/binding-freebsd-x64": "1.1.3",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+                "@rolldown/binding-linux-arm64-musl": "1.1.3",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+                "@rolldown/binding-linux-x64-gnu": "1.1.3",
+                "@rolldown/binding-linux-x64-musl": "1.1.3",
+                "@rolldown/binding-openharmony-arm64": "1.1.3",
+                "@rolldown/binding-wasm32-wasi": "1.1.3",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+                "@rolldown/binding-win32-x64-msvc": "1.1.3"
+            }
+        },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/rrweb-cssom": {
@@ -18196,10 +17291,16 @@
             "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
             "license": "ISC"
         },
+        "node_modules/semifies": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+            "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+            "license": "Apache-2.0"
+        },
         "node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -18209,66 +17310,71 @@
             }
         },
         "node_modules/send": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
             "license": "MIT",
             "dependencies": {
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "mime": "1.6.0",
-                "ms": "2.1.3",
-                "on-finished": "2.4.1",
-                "range-parser": "~1.2.1",
-                "statuses": "2.0.1"
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/send/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/send/node_modules/debug/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "license": "MIT"
-        },
-        "node_modules/send/node_modules/encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+        "node_modules/seroval": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
+            "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 0.8"
+                "node": ">=10"
+            }
+        },
+        "node_modules/seroval-plugins": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.4.tgz",
+            "integrity": "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "seroval": "^1.0"
             }
         },
         "node_modules/serve-static": {
-            "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
             "license": "MIT",
             "dependencies": {
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "0.19.0"
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/server-destroy": {
@@ -18276,12 +17382,6 @@
             "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
             "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
             "license": "ISC"
-        },
-        "node_modules/set-cookie-parser": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-            "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-            "license": "MIT"
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
@@ -18357,6 +17457,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/side-channel": {
@@ -18435,7 +17548,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=14"
@@ -18484,11 +17596,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/source-map": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+        "node_modules/solid-js": {
+            "version": "1.9.13",
+            "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.13.tgz",
+            "integrity": "sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "csstype": "^3.1.0",
+                "seroval": "~1.5.0",
+                "seroval-plugins": "~1.5.0"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -18511,15 +17634,6 @@
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
-            }
-        },
-        "node_modules/source-map-support/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/space-separated-tokens": {
@@ -18563,9 +17677,9 @@
             }
         },
         "node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -18584,23 +17698,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/string-argv": {
             "version": "0.3.2",
@@ -18653,7 +17750,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
             "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eastasianwidth": "^0.2.0",
@@ -18672,7 +17768,6 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -18687,7 +17782,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -18697,14 +17791,12 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -18829,7 +17921,6 @@
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
             "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
@@ -18846,7 +17937,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -18859,7 +17949,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -18928,13 +18017,6 @@
             "dependencies": {
                 "inline-style-parser": "0.2.7"
             }
-        },
-        "node_modules/stylis": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-            "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/sugarss": {
             "version": "5.0.1",
@@ -19036,20 +18118,24 @@
             }
         },
         "node_modules/tailwindcss": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.12.tgz",
-            "integrity": "sha512-bT0hJo91FtncsAMSsMzUkoo/iEU0Xs5xgFgVC9XmdM9bw5MhZuQFjPNl6wxAE0SiQF/YTZJa+PndGWYSDtuxAg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+            "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/tapable": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/test-exclude": {
@@ -19120,9 +18206,9 @@
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.16",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
@@ -19238,27 +18324,6 @@
             "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
             "license": "Apache-2.0"
         },
-        "node_modules/tsconfck": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.5.tgz",
-            "integrity": "sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "tsconfck": "bin/tsconfck.js"
-            },
-            "engines": {
-                "node": "^18 || >=20"
-            },
-            "peerDependencies": {
-                "typescript": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -19289,9 +18354,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+            "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
                 "tagged-tag": "^1.0.0"
@@ -19304,16 +18369,34 @@
             }
         },
         "node_modules/type-is": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
             "license": "MIT",
             "dependencies": {
-                "media-typer": "0.3.0",
-                "mime-types": "~2.1.24"
+                "content-type": "^2.0.0",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/typed-array-buffer": {
@@ -19394,13 +18477,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/typescript": {
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -19432,6 +18508,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/undici": {
+            "version": "6.27.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+            "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
             }
         },
         "node_modules/undici-types": {
@@ -19722,19 +18807,11 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/utils-merge": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/uuid": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
             "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
@@ -19811,23 +18888,22 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+            "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.25.0",
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2",
-                "postcss": "^8.5.3",
-                "rollup": "^4.34.9",
-                "tinyglobby": "^0.2.13"
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.15",
+                "rolldown": "~1.1.2",
+                "tinyglobby": "^0.2.17"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -19836,14 +18912,15 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
                 "terser": "^5.16.0",
                 "tsx": "^4.8.1",
                 "yaml": "^2.4.2"
@@ -19852,13 +18929,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {
@@ -19880,54 +18960,6 @@
                     "optional": true
                 },
                 "yaml": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/vite-node": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-            "license": "MIT",
-            "dependencies": {
-                "cac": "^6.7.14",
-                "debug": "^4.4.1",
-                "es-module-lexer": "^1.7.0",
-                "pathe": "^2.0.3",
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-            },
-            "bin": {
-                "vite-node": "vite-node.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "node_modules/vite-node/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "license": "MIT"
-        },
-        "node_modules/vite-tsconfig-paths": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
-            "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.1.1",
-                "globrex": "^0.1.2",
-                "tsconfck": "^3.0.3"
-            },
-            "peerDependencies": {
-                "vite": "*"
-            },
-            "peerDependenciesMeta": {
-                "vite": {
                     "optional": true
                 }
             }
@@ -20180,7 +19212,6 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
             "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^6.1.0",
@@ -20199,7 +19230,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -20217,7 +19247,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -20227,7 +19256,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -20243,14 +19271,12 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/wrap-ansi-cjs/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -20265,7 +19291,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -20278,7 +19303,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -16,20 +16,20 @@
         "@google-cloud/local-auth": "^3.0.1",
         "@google/genai": "^2.7.0",
         "@hello-pangea/dnd": "^18.0.1",
-        "@mantine/carousel": "^9.2.2",
-        "@mantine/core": "^9.2.2",
-        "@mantine/dates": "^9.2.2",
-        "@mantine/hooks": "^9.2.2",
-        "@mantine/modals": "^9.2.2",
-        "@mantine/notifications": "^9.2.2",
+        "@mantine/carousel": "^9.4.0",
+        "@mantine/core": "^9.4.0",
+        "@mantine/dates": "^9.4.0",
+        "@mantine/hooks": "^9.4.0",
+        "@mantine/modals": "^9.4.0",
+        "@mantine/notifications": "^9.4.0",
         "@react-google-maps/api": "^2.20.8",
-        "@react-router/node": "^7.16.0",
-        "@react-router/serve": "^7.16.0",
-        "@sentry/profiling-node": "^10.55.0",
-        "@sentry/react-router": "^10.55.0",
+        "@react-router/node": "^8.0.1",
+        "@react-router/serve": "^8.0.1",
+        "@sentry/profiling-node": "^10.60.0",
+        "@sentry/react-router": "^10.60.0",
         "@tabler/icons-react": "^3.44.0",
         "@vercel/react-router": "^1.3.1",
-        "appwrite": "^25.2.0",
+        "appwrite": "^26.0.0",
         "calendar-link": "^2.11.2",
         "canvas-confetti": "^1.9.4",
         "clsx": "^2.1.1",
@@ -40,26 +40,25 @@
         "embla-carousel-autoplay": "^8.6.0",
         "embla-carousel-react": "^8.6.0",
         "firebase": "^12.14.0",
-        "google-auth-library": "^9.15.1",
-        "googleapis": "^146.0.0",
+        "google-auth-library": "^10.7.0",
+        "googleapis": "^173.0.0",
         "isbot": "^5.1.40",
         "luxon": "^3.7.2",
-        "node-appwrite": "^25.2.0",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6",
+        "node-appwrite": "^26.2.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "react-imask": "^7.6.1",
         "react-joyride": "^3.1.0",
         "react-markdown": "^10.1.0",
-        "react-router": "^7.16.0"
+        "react-router": "^8.0.1"
     },
     "devDependencies": {
         "@babel/preset-env": "^7.29.7",
         "@babel/preset-react": "^7.29.7",
         "@eslint/js": "^9.39.4",
-        "@netlify/vite-plugin-react-router": "^1.0.1",
-        "@react-router/dev": "^7.16.0",
+        "@react-router/dev": "^8.0.1",
         "@sentry/vite-plugin": "^5.3.0",
-        "@tailwindcss/vite": "^4.0.0",
+        "@tailwindcss/vite": "^4.3.1",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -83,13 +82,28 @@
         "postcss-preset-mantine": "^1.18.0",
         "postcss-simple-vars": "^7.0.1",
         "prettier": "3.6.2",
-        "react-router-devtools": "^1.1.10",
-        "tailwindcss": "^4.0.0",
+        "react-router-devtools": "^6.2.1",
+        "tailwindcss": "^4.3.1",
         "typescript": "^5.9.3",
-        "vite": "^6.4.2",
-        "vite-tsconfig-paths": "^5.1.4"
+        "vite": "^8.1.0"
     },
     "lint-staged": {
         "**/*": "prettier --write --ignore-unknown"
+    },
+    "overrides": {
+        "@sentry/react-router": {
+            "react-router": "$react-router",
+            "@react-router/node": "$@react-router/node"
+        },
+        "@vercel/react-router": {
+            "@react-router/dev": "$@react-router/dev",
+            "@react-router/node": "$@react-router/node"
+        },
+        "@tailwindcss/vite": {
+            "vite": "$vite"
+        },
+        "react-router-devtools": {
+            "vite": "$vite"
+        }
     }
 }

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -4,11 +4,4 @@ export default {
     // Config options...
     // Server-side render by default, to enable SPA mode set this to `false`
     ssr: true,
-    future: {
-        v8_middleware: true,
-        v8_splitRouteModules: true,
-        v8_viteEnvironmentApi: true,
-        v8_passThroughRequests: true,
-        v8_trailingSlashAwareDataRequests: true,
-    },
 } satisfies Config;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,6 @@
 import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 // import netlifyPlugin from '@netlify/vite-plugin-react-router'
 
@@ -15,7 +14,6 @@ export default defineConfig({
     plugins: [
         tailwindcss(),
         reactRouter(),
-        tsconfigPaths(),
         ...(process.env.SENTRY_AUTH_TOKEN
             ? [
                   sentryVitePlugin({
@@ -31,6 +29,7 @@ export default defineConfig({
         // netlifyPlugin(),
     ],
     resolve: {
+        tsconfigPaths: true,
         alias: {
             "@": "/app",
             "@actions": "/actions",


### PR DESCRIPTION
[![Render.com PR #220 ENV](https://img.shields.io/badge/Render.com%20PR%20%23220%20ENV-blue)](https://softball-manager-react-router-pr-220.onrender.com/)

This PR upgrades React Router to v8, React to v19.2.7, Vite to v8.1.0, Appwrite, Google APIs, Sentry, Tailwind CSS, and Mantine to their latest major versions. 

It also includes fixes for the Jest test suite to properly handle React Router's new ESM-only module format.

All tests are passing.
