### PR TITLE
fix: Resolve opponent lineup wrap race condition

### DIFF
--- a/app/routes/gameday/components/DesktopGamedayContainer.jsx
+++ b/app/routes/gameday/components/DesktopGamedayContainer.jsx
@@ -244,6 +244,8 @@ export default function DesktopGamedayContainer({
                             onOpenSelectBatterDrawer={openSelectBatter}
                             opponentLineupLocked={game.opponentLineupLocked}
                             game={game}
+                            inning={inning}
+                            halfInning={halfInning}
                         />
                     ) : (
                         <div style={{ minWidth: 40 }} />

--- a/app/routes/gameday/components/GamedayMenu.jsx
+++ b/app/routes/gameday/components/GamedayMenu.jsx
@@ -28,6 +28,8 @@ export default function GamedayMenu({
     opponentLineupLocked,
     menuId,
     game,
+    inning,
+    halfInning,
 }) {
     const fetcher = useFetcher();
     const { eventId } = useParams();
@@ -200,10 +202,8 @@ export default function GamedayMenu({
                                         oldOpponentLineup:
                                             JSON.stringify(opponentChart),
                                         teamId: game?.teamId,
-                                        inning: String(
-                                            game?.currentInning || 1,
-                                        ),
-                                        halfInning: game?.halfInning || "top",
+                                        inning: String(inning || 1),
+                                        halfInning: halfInning || "top",
                                     },
                                     { method: "post" },
                                 );

--- a/app/routes/gameday/components/MobileGamedayContainer.jsx
+++ b/app/routes/gameday/components/MobileGamedayContainer.jsx
@@ -216,6 +216,8 @@ export default function MobileGamedayContainer({
                             onOpenSelectBatterDrawer={openSelectBatter}
                             opponentLineupLocked={game.opponentLineupLocked}
                             game={game}
+                            inning={inning}
+                            halfInning={halfInning}
                         />
                     ) : (
                         <div style={{ minWidth: 40 }} />

--- a/app/routes/gameday/components/tests/GamedayMenu.test.jsx
+++ b/app/routes/gameday/components/tests/GamedayMenu.test.jsx
@@ -78,7 +78,9 @@ describe("GamedayMenu", () => {
                 gameFinal={false}
                 score={5}
                 opponentScore={3}
-                game={{ teamId: "t1", currentInning: 1, halfInning: "top" }}
+                game={{ teamId: "t1" }}
+                inning={1}
+                halfInning="top"
                 {...props}
             />,
         );

--- a/app/routes/gameday/hooks/tests/useGameState.test.jsx
+++ b/app/routes/gameday/hooks/tests/useGameState.test.jsx
@@ -246,6 +246,31 @@ describe("useGameState", () => {
         expect(result.current.opponentOrderIndex).toBe(2);
     });
 
+    it("sets opponentOrderIndex to 0 when last log is opponent_lineup_wrap", () => {
+        const game = {
+            score: 0,
+            opponentScore: 0,
+            isHomeGame: true,
+            opponentLineupLocked: true,
+        };
+        const logs = [
+            {
+                $id: "opp_log1",
+                inning: 1,
+                halfInning: "top",
+                eventType: "opponent_lineup_wrap",
+                baseState: JSON.stringify({ isOpponent: true }),
+            },
+        ];
+
+        const { result } = renderHook(() =>
+            useGameState({ logs, game, playerChart, opponentChart: [] }),
+        );
+
+        // opponent_lineup_wrap should reset the active batter to index 0
+        expect(result.current.opponentOrderIndex).toBe(0);
+    });
+
     it("skips players who are marked as removed with type 'skip'", () => {
         const playerChartWithRemoved = [
             { $id: "p1", firstName: "Alice" },

--- a/app/routes/gameday/hooks/useGameState.js
+++ b/app/routes/gameday/hooks/useGameState.js
@@ -44,7 +44,11 @@ export function useGameState({ logs, game, playerChart, opponentChart }) {
                     log.eventType !== "INJURY_REMOVE"
                 ) {
                     if (isOpponentPlay(log, game.isHomeGame)) {
-                        if (!lastOpponentAtBatLog && log.playerId) {
+                        if (
+                            !lastOpponentAtBatLog &&
+                            (log.playerId ||
+                                log.eventType === "opponent_lineup_wrap")
+                        ) {
                             lastOpponentAtBatLog = log;
                         }
                     } else {
@@ -76,7 +80,9 @@ export function useGameState({ logs, game, playerChart, opponentChart }) {
             if (lastOpponentAtBatLog) {
                 let nextOpponentIndex = 0;
 
-                if (opponentChart && opponentChart.length > 0) {
+                if (lastOpponentAtBatLog.eventType === "opponent_lineup_wrap") {
+                    nextOpponentIndex = 0;
+                } else if (opponentChart && opponentChart.length > 0) {
                     const lastOpponentIndex = opponentChart.findIndex(
                         (p) => p.$id === lastOpponentAtBatLog.playerId,
                     );


### PR DESCRIPTION
[![Render.com PR #226 ENV](https://img.shields.io/badge/Render.com%20PR%20%23226%20ENV-blue)](https://softball-manager-react-router-pr-226.onrender.com/)

This PR resolves a race condition where locking and wrapping the opponent lineup from the UI didn't update the `opponentOrderIndex` properly because `opponentChart` updates asynchronously. We now explicitly check for the `opponent_lineup_wrap` log and force the active index to 0, which bypasses the race condition.

- Added `inning` and `halfInning` to `GamedayMenu` to allow the action to log correctly.
- Added tests for `useGameState` covering the wrap event.
