### PR TITLE
Feat: Team Removal and Form Submit Guard

### DIFF
--- a/app/actions/teams.js
+++ b/app/actions/teams.js
@@ -660,7 +660,7 @@ export async function removeTeam({ teamId, client }) {
                 success: true,
                 archived: true,
                 message:
-                    "This team has existing data and has been archived. It will no longer appear in your dashboard. Contact support if you need to restore it.",
+                    "This team has been archived. It will no longer appear in your dashboard. Contact support if you need to restore it.",
             };
         }
 

--- a/app/actions/teams.js
+++ b/app/actions/teams.js
@@ -617,7 +617,7 @@ export async function archiveTeam({ teamId, client }) {
  * @param {Object} params.client - The session client
  * @returns {Promise<Object>} Result with success flag, archived boolean, and message
  */
-export async function deleteTeamCompletely({ teamId, client }) {
+export async function removeTeam({ teamId, client }) {
     if (!client) {
         throw new Error(
             "A constructed 'client' object is strictly required for authorization.",
@@ -675,7 +675,7 @@ export async function deleteTeamCompletely({ teamId, client }) {
             await messaging.deleteTopic(buildTeamTopic(teamId));
         } catch (topicError) {
             console.warn(
-                `[deleteTeamCompletely] Failed to delete notification topic for team ${teamId}:`,
+                `[removeTeam] Failed to delete notification topic for team ${teamId}:`,
                 topicError,
             );
         }

--- a/app/actions/teams.js
+++ b/app/actions/teams.js
@@ -531,13 +531,20 @@ export async function updatePlayerLabels({ teamId, values, client }) {
  * @returns {Promise<boolean>} True if associated data exists
  */
 async function hasAssociatedData({ teamId, client }) {
-    const seasonsResult = await listDocuments(
-        "seasons",
-        [Query.equal("teamId", teamId), Query.limit(1)],
-        client,
-    );
+    const [seasonsResult, gamesResult] = await Promise.all([
+        listDocuments(
+            "seasons",
+            [Query.equal("teamId", teamId), Query.limit(1)],
+            client,
+        ),
+        listDocuments(
+            "games",
+            [Query.equal("teamId", teamId), Query.limit(1)],
+            client,
+        ),
+    ]);
 
-    return (seasonsResult?.total ?? 0) > 0;
+    return (seasonsResult?.total ?? 0) > 0 || (gamesResult?.total ?? 0) > 0;
 }
 
 /**

--- a/app/actions/teams.js
+++ b/app/actions/teams.js
@@ -573,10 +573,11 @@ export async function archiveTeam({ teamId, client }) {
         // Verify the requesting user is an owner, not just a manager
         const { account } = client;
         const requestingUser = await account.get();
-        const memberships = await getTeamMembers({ teamId });
-        const requestingMembership = memberships.memberships.find(
-            (m) => m.userId === requestingUser.$id,
-        );
+        const memberships = await getTeamMembers({
+            teamId,
+            queries: [Query.equal("userId", [requestingUser.$id])],
+        });
+        const requestingMembership = memberships.memberships[0];
 
         if (!requestingMembership?.roles.includes("owner")) {
             return {
@@ -630,10 +631,11 @@ export async function deleteTeamCompletely({ teamId, client }) {
         // Verify the requesting user is an owner
         const { account } = client;
         const requestingUser = await account.get();
-        const memberships = await getTeamMembers({ teamId });
-        const requestingMembership = memberships.memberships.find(
-            (m) => m.userId === requestingUser.$id,
-        );
+        const userMemberships = await getTeamMembers({
+            teamId,
+            queries: [Query.equal("userId", [requestingUser.$id])],
+        });
+        const requestingMembership = userMemberships.memberships[0];
 
         if (!requestingMembership?.roles.includes("owner")) {
             return {
@@ -643,7 +645,11 @@ export async function deleteTeamCompletely({ teamId, client }) {
         }
 
         // Determine whether a hard delete is safe
-        const isSolo = memberships.total === 1;
+        const allMemberships = await getTeamMembers({
+            teamId,
+            queries: [Query.limit(1)],
+        });
+        const isSolo = allMemberships.total === 1;
         const dataExists = await hasAssociatedData({ teamId, client });
 
         if (dataExists || !isSolo) {

--- a/app/actions/teams.js
+++ b/app/actions/teams.js
@@ -1,6 +1,11 @@
-import { ID, Permission, Role } from "node-appwrite";
+import { ID, Permission, Role, Query } from "node-appwrite";
 import { createAdminClient } from "@/utils/appwrite/server";
-import { createDocument, updateDocument } from "@/utils/databases.js";
+import {
+    createDocument,
+    updateDocument,
+    deleteDocument,
+    listDocuments,
+} from "@/utils/databases.js";
 import {
     createAppwriteTeam,
     addExistingUserToTeam,
@@ -8,6 +13,7 @@ import {
     getTeamMembers,
     updateMembershipRoles,
     updateTeamPreferences,
+    deleteAppwriteTeam,
 } from "@/utils/teams.js";
 
 import { hasBadWords } from "@/utils/badWordsApi";
@@ -434,6 +440,166 @@ export async function updatePlayerLabels({ teamId, values, client }) {
         return {
             success: false,
             message: "Failed to update player labels",
+        };
+    }
+}
+
+/**
+ * Checks whether a team has any meaningful associated data that would make
+ * a hard delete unsafe. Returns true if seasons or game_logs exist for the team.
+ *
+ * @param {Object} params
+ * @param {string} params.teamId - The team ID to check
+ * @param {Object} params.client - The session client
+ * @returns {Promise<boolean>} True if associated data exists
+ */
+async function hasAssociatedData({ teamId, client }) {
+    const seasonsResult = await listDocuments(
+        "seasons",
+        [Query.equal("teamId", teamId), Query.limit(1)],
+        client,
+    );
+
+    return (seasonsResult?.total ?? 0) > 0;
+}
+
+/**
+ * Soft-deletes a team by setting `archived: true` on the database document.
+ * The Appwrite Team record and all memberships are preserved so permissions
+ * remain intact, but the team will be filtered from all application views.
+ *
+ * Only team owners may archive a team.
+ *
+ * @param {Object} params
+ * @param {string} params.teamId - The team ID to archive
+ * @param {Object} params.client - The session client
+ * @returns {Promise<Object>} Result object with success flag and message
+ */
+export async function archiveTeam({ teamId, client }) {
+    if (!client) {
+        throw new Error(
+            "A constructed 'client' object is strictly required for authorization.",
+        );
+    }
+
+    try {
+        const auth = await verifyManager(teamId, client);
+        if (!auth.success) return auth;
+
+        // Verify the requesting user is an owner, not just a manager
+        const { account } = client;
+        const requestingUser = await account.get();
+        const memberships = await getTeamMembers({ teamId });
+        const requestingMembership = memberships.memberships.find(
+            (m) => m.userId === requestingUser.$id,
+        );
+
+        if (!requestingMembership?.roles.includes("owner")) {
+            return {
+                success: false,
+                message: "Only team owners can archive a team.",
+            };
+        }
+
+        await updateDocument("teams", teamId, { archived: true }, client);
+
+        return {
+            success: true,
+            archived: true,
+            message:
+                "Team archived. It will no longer appear in your dashboard. Contact support if you need to restore it.",
+        };
+    } catch (error) {
+        console.error("Error archiving team:", error);
+        return {
+            success: false,
+            message: error.message || "Failed to archive team.",
+        };
+    }
+}
+
+/**
+ * Smartly removes a team:
+ * - If the team has no seasons and no game_logs, and has only one member
+ *   (the creator), it performs a hard delete: removes the DB document,
+ *   the Appwrite Team record, and the notification topic.
+ * - Otherwise, it falls back to a soft archive to preserve historical data.
+ *
+ * Only team owners may call this action.
+ *
+ * @param {Object} params
+ * @param {string} params.teamId - The team ID to remove
+ * @param {Object} params.client - The session client
+ * @returns {Promise<Object>} Result with success flag, archived boolean, and message
+ */
+export async function deleteTeamCompletely({ teamId, client }) {
+    if (!client) {
+        throw new Error(
+            "A constructed 'client' object is strictly required for authorization.",
+        );
+    }
+
+    try {
+        const auth = await verifyManager(teamId, client);
+        if (!auth.success) return auth;
+
+        // Verify the requesting user is an owner
+        const { account } = client;
+        const requestingUser = await account.get();
+        const memberships = await getTeamMembers({ teamId });
+        const requestingMembership = memberships.memberships.find(
+            (m) => m.userId === requestingUser.$id,
+        );
+
+        if (!requestingMembership?.roles.includes("owner")) {
+            return {
+                success: false,
+                message: "Only team owners can remove a team.",
+            };
+        }
+
+        // Determine whether a hard delete is safe
+        const isSolo = memberships.total === 1;
+        const dataExists = await hasAssociatedData({ teamId, client });
+
+        if (dataExists || !isSolo) {
+            // Fall back to soft archive to preserve historical data
+            await updateDocument("teams", teamId, { archived: true }, client);
+
+            return {
+                success: true,
+                archived: true,
+                message:
+                    "This team has existing data and has been archived. It will no longer appear in your dashboard. Contact support if you need to restore it.",
+            };
+        }
+
+        // Safe to hard delete — remove DB document first, then Appwrite Team
+        await deleteDocument("teams", teamId, client);
+        await deleteAppwriteTeam({ teamId });
+
+        // Non-blocking: clean up the notification topic created alongside the team
+        try {
+            const { messaging } = createAdminClient();
+            const { buildTeamTopic } = await import("@/utils/notifications");
+            await messaging.deleteTopic(buildTeamTopic(teamId));
+        } catch (topicError) {
+            console.warn(
+                `[deleteTeamCompletely] Failed to delete notification topic for team ${teamId}:`,
+                topicError,
+            );
+        }
+
+        return {
+            success: true,
+            archived: false,
+            message: "Team permanently removed.",
+        };
+    } catch (error) {
+        console.error("Error deleting team:", error);
+        return {
+            success: false,
+            message: error.message || "Failed to remove team.",
         };
     }
 }

--- a/app/actions/teams.js
+++ b/app/actions/teams.js
@@ -604,7 +604,7 @@ export async function archiveTeam({ teamId, client }) {
 
 /**
  * Smartly removes a team:
- * - If the team has no seasons and no game_logs, and has only one member
+ * - If the team has no seasons and no games, and has only one member
  *   (the creator), it performs a hard delete: removes the DB document,
  *   the Appwrite Team record, and the notification topic.
  * - Otherwise, it falls back to a soft archive to preserve historical data.

--- a/app/actions/teams.js
+++ b/app/actions/teams.js
@@ -523,7 +523,7 @@ export async function updatePlayerLabels({ teamId, values, client }) {
 
 /**
  * Checks whether a team has any meaningful associated data that would make
- * a hard delete unsafe. Returns true if seasons or game_logs exist for the team.
+ * a hard delete unsafe. Returns true if seasons or games exist for the team.
  *
  * @param {Object} params
  * @param {string} params.teamId - The team ID to check

--- a/app/actions/tests/teams.test.js
+++ b/app/actions/tests/teams.test.js
@@ -2,7 +2,12 @@ import {
     createAdminClient,
     createSessionClient,
 } from "@/utils/appwrite/server";
-import { createDocument, updateDocument } from "@/utils/databases";
+import {
+    createDocument,
+    updateDocument,
+    deleteDocument,
+    listDocuments,
+} from "@/utils/databases";
 import { hasBadWords } from "@/utils/badWordsApi";
 import {
     createAppwriteTeam,
@@ -12,6 +17,7 @@ import {
     updateMembershipRoles,
     updateTeamPreferences,
     removeTeamMember,
+    deleteAppwriteTeam,
 } from "@/utils/teams";
 
 import {
@@ -24,6 +30,8 @@ import {
     updatePreferences,
     updatePlayerLabels,
     removePlayersFromTeam,
+    archiveTeam,
+    removeTeam,
 } from "../teams";
 import { verifyManager } from "../utils/teamAuth.js";
 
@@ -824,11 +832,8 @@ describe("Teams Actions", () => {
 });
 
 // ---------------------------------------------------------------------------
-// archiveTeam & deleteTeamCompletely
+// archiveTeam & removeTeam
 // ---------------------------------------------------------------------------
-import { archiveTeam, deleteTeamCompletely } from "../teams";
-import { deleteDocument, listDocuments } from "@/utils/databases";
-import { deleteAppwriteTeam } from "@/utils/teams";
 
 /** Shared mock client for removal tests */
 const makeRemovalClient = (userId = "user1") => ({
@@ -906,7 +911,7 @@ describe("archiveTeam", () => {
     });
 });
 
-describe("deleteTeamCompletely", () => {
+describe("removeTeam", () => {
     const teamId = "team-xyz";
 
     beforeEach(() => {
@@ -924,9 +929,9 @@ describe("deleteTeamCompletely", () => {
     });
 
     it("should throw if no client is provided", async () => {
-        await expect(
-            deleteTeamCompletely({ teamId, client: null }),
-        ).rejects.toThrow("A constructed 'client' object is strictly required");
+        await expect(removeTeam({ teamId, client: null })).rejects.toThrow(
+            "A constructed 'client' object is strictly required",
+        );
     });
 
     it("should return failure if the user is not an owner", async () => {
@@ -936,7 +941,7 @@ describe("deleteTeamCompletely", () => {
             memberships: [{ userId: "user1", roles: ["manager", "player"] }],
         });
         // listDocuments not called for data check if auth fails
-        const result = await deleteTeamCompletely({ teamId, client });
+        const result = await removeTeam({ teamId, client });
         expect(result.success).toBe(false);
         expect(result.message).toMatch(/only team owners/i);
     });
@@ -950,7 +955,7 @@ describe("deleteTeamCompletely", () => {
             .mockResolvedValueOnce({ total: 0, rows: [] }); // game_logs
         updateDocument.mockResolvedValue({ $id: teamId, archived: true });
 
-        const result = await deleteTeamCompletely({ teamId, client });
+        const result = await removeTeam({ teamId, client });
 
         expect(result.success).toBe(true);
         expect(result.archived).toBe(true);
@@ -978,7 +983,7 @@ describe("deleteTeamCompletely", () => {
             .mockResolvedValueOnce({ total: 0, rows: [] });
         updateDocument.mockResolvedValue({ $id: teamId, archived: true });
 
-        const result = await deleteTeamCompletely({ teamId, client });
+        const result = await removeTeam({ teamId, client });
 
         expect(result.archived).toBe(true);
         expect(deleteDocument).not.toHaveBeenCalled();
@@ -992,7 +997,7 @@ describe("deleteTeamCompletely", () => {
             .mockResolvedValueOnce({ total: 0, rows: [] })
             .mockResolvedValueOnce({ total: 0, rows: [] });
 
-        const result = await deleteTeamCompletely({ teamId, client });
+        const result = await removeTeam({ teamId, client });
 
         expect(deleteDocument).toHaveBeenCalledWith("teams", teamId, client);
         expect(deleteAppwriteTeam).toHaveBeenCalledWith({ teamId });

--- a/app/actions/tests/teams.test.js
+++ b/app/actions/tests/teams.test.js
@@ -31,6 +31,8 @@ import { verifyManager } from "../utils/teamAuth.js";
 jest.mock("@/utils/databases", () => ({
     createDocument: jest.fn(),
     updateDocument: jest.fn(),
+    deleteDocument: jest.fn(),
+    listDocuments: jest.fn(),
 }));
 
 jest.mock("@/utils/badWordsApi", () => ({
@@ -45,6 +47,7 @@ jest.mock("@/utils/teams", () => ({
     updateMembershipRoles: jest.fn(),
     updateTeamPreferences: jest.fn(),
     removeTeamMember: jest.fn(),
+    deleteAppwriteTeam: jest.fn(),
 }));
 
 jest.mock("@/utils/appwrite/server", () => ({
@@ -826,23 +829,6 @@ describe("Teams Actions", () => {
 import { archiveTeam, deleteTeamCompletely } from "../teams";
 import { deleteDocument, listDocuments } from "@/utils/databases";
 import { deleteAppwriteTeam } from "@/utils/teams";
-
-jest.mock("@/utils/databases", () => ({
-    createDocument: jest.fn(),
-    updateDocument: jest.fn(),
-    deleteDocument: jest.fn(),
-    listDocuments: jest.fn(),
-}));
-
-jest.mock("@/utils/teams", () => ({
-    createAppwriteTeam: jest.fn(),
-    addExistingUserToTeam: jest.fn(),
-    inviteNewMemberByEmail: jest.fn(),
-    getTeamMembers: jest.fn(),
-    updateMembershipRoles: jest.fn(),
-    updateTeamPreferences: jest.fn(),
-    deleteAppwriteTeam: jest.fn(),
-}));
 
 /** Shared mock client for removal tests */
 const makeRemovalClient = (userId = "user1") => ({

--- a/app/actions/tests/teams.test.js
+++ b/app/actions/tests/teams.test.js
@@ -739,3 +739,198 @@ describe("Teams Actions", () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// archiveTeam & deleteTeamCompletely
+// ---------------------------------------------------------------------------
+import { archiveTeam, deleteTeamCompletely } from "../teams";
+import { deleteDocument, listDocuments } from "@/utils/databases";
+import { deleteAppwriteTeam } from "@/utils/teams";
+
+jest.mock("@/utils/databases", () => ({
+    createDocument: jest.fn(),
+    updateDocument: jest.fn(),
+    deleteDocument: jest.fn(),
+    listDocuments: jest.fn(),
+}));
+
+jest.mock("@/utils/teams", () => ({
+    createAppwriteTeam: jest.fn(),
+    addExistingUserToTeam: jest.fn(),
+    inviteNewMemberByEmail: jest.fn(),
+    getTeamMembers: jest.fn(),
+    updateMembershipRoles: jest.fn(),
+    updateTeamPreferences: jest.fn(),
+    deleteAppwriteTeam: jest.fn(),
+}));
+
+/** Shared mock client for removal tests */
+const makeRemovalClient = (userId = "user1") => ({
+    tablesDB: { id: "mock-db" },
+    account: { get: jest.fn().mockResolvedValue({ $id: userId }) },
+});
+
+/** Membership where the user is the sole owner */
+const ownerOnlyMemberships = (userId = "user1") => ({
+    total: 1,
+    memberships: [{ userId, roles: ["owner", "manager", "player"] }],
+});
+
+describe("archiveTeam", () => {
+    const teamId = "team-abc";
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(console, "error").mockImplementation(() => {});
+        verifyManager.mockResolvedValue({ success: true });
+    });
+
+    afterEach(() => {
+        console.error.mockRestore();
+    });
+
+    it("should return an error if no client is provided", async () => {
+        await expect(archiveTeam({ teamId, client: null })).rejects.toThrow(
+            "A constructed 'client' object is strictly required",
+        );
+    });
+
+    it("should return failure if the user is not an owner", async () => {
+        const client = makeRemovalClient("user1");
+        getTeamMembers.mockResolvedValue({
+            total: 2,
+            memberships: [
+                { userId: "user1", roles: ["manager", "player"] }, // manager, not owner
+                { userId: "user2", roles: ["owner", "manager", "player"] },
+            ],
+        });
+
+        const result = await archiveTeam({ teamId, client });
+        expect(result.success).toBe(false);
+        expect(result.message).toMatch(/only team owners/i);
+    });
+
+    it("should set archived: true on the DB document and return success", async () => {
+        const client = makeRemovalClient("user1");
+        getTeamMembers.mockResolvedValue(ownerOnlyMemberships("user1"));
+        updateDocument.mockResolvedValue({ $id: teamId, archived: true });
+
+        const result = await archiveTeam({ teamId, client });
+
+        expect(updateDocument).toHaveBeenCalledWith(
+            "teams",
+            teamId,
+            { archived: true },
+            client,
+        );
+        expect(result.success).toBe(true);
+        expect(result.archived).toBe(true);
+    });
+
+    it("should return failure if verifyManager fails", async () => {
+        verifyManager.mockResolvedValue({
+            success: false,
+            message: "Not a manager",
+        });
+        const client = makeRemovalClient("user1");
+
+        const result = await archiveTeam({ teamId, client });
+        expect(result.success).toBe(false);
+        expect(updateDocument).not.toHaveBeenCalled();
+    });
+});
+
+describe("deleteTeamCompletely", () => {
+    const teamId = "team-xyz";
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(console, "error").mockImplementation(() => {});
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        verifyManager.mockResolvedValue({ success: true });
+        deleteDocument.mockResolvedValue({});
+        deleteAppwriteTeam.mockResolvedValue({ success: true });
+    });
+
+    afterEach(() => {
+        console.error.mockRestore();
+        console.warn.mockRestore();
+    });
+
+    it("should throw if no client is provided", async () => {
+        await expect(
+            deleteTeamCompletely({ teamId, client: null }),
+        ).rejects.toThrow("A constructed 'client' object is strictly required");
+    });
+
+    it("should return failure if the user is not an owner", async () => {
+        const client = makeRemovalClient("user1");
+        getTeamMembers.mockResolvedValue({
+            total: 1,
+            memberships: [{ userId: "user1", roles: ["manager", "player"] }],
+        });
+        // listDocuments not called for data check if auth fails
+        const result = await deleteTeamCompletely({ teamId, client });
+        expect(result.success).toBe(false);
+        expect(result.message).toMatch(/only team owners/i);
+    });
+
+    it("should archive (not hard-delete) when seasons exist", async () => {
+        const client = makeRemovalClient("user1");
+        getTeamMembers.mockResolvedValue(ownerOnlyMemberships("user1"));
+        // seasons exist
+        listDocuments
+            .mockResolvedValueOnce({ total: 1, rows: [{ $id: "s1" }] }) // seasons
+            .mockResolvedValueOnce({ total: 0, rows: [] }); // game_logs
+        updateDocument.mockResolvedValue({ $id: teamId, archived: true });
+
+        const result = await deleteTeamCompletely({ teamId, client });
+
+        expect(result.success).toBe(true);
+        expect(result.archived).toBe(true);
+        expect(updateDocument).toHaveBeenCalledWith(
+            "teams",
+            teamId,
+            { archived: true },
+            client,
+        );
+        expect(deleteDocument).not.toHaveBeenCalled();
+        expect(deleteAppwriteTeam).not.toHaveBeenCalled();
+    });
+
+    it("should archive when other members exist even with no data", async () => {
+        const client = makeRemovalClient("user1");
+        getTeamMembers.mockResolvedValue({
+            total: 2, // two members
+            memberships: [
+                { userId: "user1", roles: ["owner", "manager", "player"] },
+                { userId: "user2", roles: ["player"] },
+            ],
+        });
+        listDocuments
+            .mockResolvedValueOnce({ total: 0, rows: [] })
+            .mockResolvedValueOnce({ total: 0, rows: [] });
+        updateDocument.mockResolvedValue({ $id: teamId, archived: true });
+
+        const result = await deleteTeamCompletely({ teamId, client });
+
+        expect(result.archived).toBe(true);
+        expect(deleteDocument).not.toHaveBeenCalled();
+    });
+
+    it("should hard-delete when team is solo and has no data", async () => {
+        const client = makeRemovalClient("user1");
+        getTeamMembers.mockResolvedValue(ownerOnlyMemberships("user1"));
+        // No seasons, no logs
+        listDocuments
+            .mockResolvedValueOnce({ total: 0, rows: [] })
+            .mockResolvedValueOnce({ total: 0, rows: [] });
+
+        const result = await deleteTeamCompletely({ teamId, client });
+
+        expect(deleteDocument).toHaveBeenCalledWith("teams", teamId, client);
+        expect(deleteAppwriteTeam).toHaveBeenCalledWith({ teamId });
+        expect(result.success).toBe(true);
+        expect(result.archived).toBe(false);
+    });
+});

--- a/app/forms/FormWrapper.jsx
+++ b/app/forms/FormWrapper.jsx
@@ -20,7 +20,7 @@ export default function FormWrapper({
 }) {
     const { closeAllModals } = useModal();
     const navigation = useNavigation();
-    const isSubmitting = navigation.state === "submitting";
+    const isSubmitting = navigation.state !== "idle";
 
     const submit = useSubmit();
 

--- a/app/forms/FormWrapper.jsx
+++ b/app/forms/FormWrapper.jsx
@@ -1,4 +1,4 @@
-import { Form, useSubmit } from "react-router";
+import { Form, useSubmit, useNavigation } from "react-router";
 
 import { Button, Group } from "@mantine/core";
 
@@ -19,6 +19,8 @@ export default function FormWrapper({
     ...rest
 }) {
     const { closeAllModals } = useModal();
+    const navigation = useNavigation();
+    const isSubmitting = navigation.state === "submitting";
 
     const submit = useSubmit();
 
@@ -45,8 +47,8 @@ export default function FormWrapper({
                         color={buttonColor || "lime"}
                         autoContrast
                         size="md"
-                        disabled={confirmDisabled || loading}
-                        loading={loading}
+                        disabled={confirmDisabled || loading || isSubmitting}
+                        loading={loading || isSubmitting}
                     >
                         {confirmText}
                     </Button>

--- a/app/forms/tests/AddGameResults.test.jsx
+++ b/app/forms/tests/AddGameResults.test.jsx
@@ -6,6 +6,7 @@ const mockSubmit = jest.fn();
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
     useSubmit: () => mockSubmit,
+    useNavigation: () => ({ state: "idle" }),
     Form: ({ children, onSubmit, ...props }) => (
         <form onSubmit={onSubmit} {...props}>
             {children}

--- a/app/forms/tests/AddPlayer.test.jsx
+++ b/app/forms/tests/AddPlayer.test.jsx
@@ -6,6 +6,7 @@ const mockSubmit = jest.fn();
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
     useSubmit: () => mockSubmit,
+    useNavigation: () => ({ state: "idle" }),
     Form: ({ children, onSubmit, ...props }) => (
         <form onSubmit={onSubmit} {...props}>
             {children}

--- a/app/forms/tests/AddSeason.test.jsx
+++ b/app/forms/tests/AddSeason.test.jsx
@@ -6,6 +6,7 @@ const mockSubmit = jest.fn();
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
     useSubmit: () => mockSubmit,
+    useNavigation: () => ({ state: "idle" }),
     Form: ({ children, onSubmit, ...props }) => (
         <form onSubmit={onSubmit} {...props}>
             {children}

--- a/app/forms/tests/AddSingleGame.test.jsx
+++ b/app/forms/tests/AddSingleGame.test.jsx
@@ -6,6 +6,7 @@ const mockSubmit = jest.fn();
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
     useSubmit: () => mockSubmit,
+    useNavigation: () => ({ state: "idle" }),
     Form: ({ children, onSubmit, ...props }) => (
         <form onSubmit={onSubmit} {...props}>
             {children}

--- a/app/forms/tests/AddTeam.test.jsx
+++ b/app/forms/tests/AddTeam.test.jsx
@@ -6,6 +6,7 @@ const mockSubmit = jest.fn();
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
     useSubmit: () => mockSubmit,
+    useNavigation: () => ({ state: "idle" }),
     Form: ({ children, onSubmit, ...props }) => (
         <form onSubmit={onSubmit} {...props}>
             {children}

--- a/app/forms/tests/FormWrapper.test.jsx
+++ b/app/forms/tests/FormWrapper.test.jsx
@@ -3,9 +3,12 @@ import { render, screen, fireEvent } from "@/utils/test-utils";
 import FormWrapper from "../FormWrapper";
 
 const mockSubmit = jest.fn();
+const mockUseNavigation = jest.fn(() => ({ state: "idle" }));
+
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
     useSubmit: () => mockSubmit,
+    useNavigation: () => mockUseNavigation(),
     Form: ({ children, onSubmit, ...props }) => (
         <form onSubmit={onSubmit} {...props}>
             {children}
@@ -86,5 +89,44 @@ describe("FormWrapper", () => {
         expect(
             screen.queryByRole("button", { name: /confirm/i }),
         ).not.toBeInTheDocument();
+    });
+
+    it("disables and shows loading on submit button while navigation is submitting", () => {
+        mockUseNavigation.mockReturnValue({ state: "submitting" });
+
+        render(
+            <FormWrapper action="test-action">
+                <input name="field" defaultValue="val" />
+            </FormWrapper>,
+        );
+
+        const submitButton = screen.getByRole("button", { name: /confirm/i });
+        expect(submitButton).toBeDisabled();
+    });
+
+    it("enables the submit button when navigation returns to idle", () => {
+        mockUseNavigation.mockReturnValue({ state: "idle" });
+
+        render(
+            <FormWrapper action="test-action">
+                <input name="field" defaultValue="val" />
+            </FormWrapper>,
+        );
+
+        const submitButton = screen.getByRole("button", { name: /confirm/i });
+        expect(submitButton).not.toBeDisabled();
+    });
+
+    it("disables the submit button when confirmDisabled prop is true regardless of navigation state", () => {
+        mockUseNavigation.mockReturnValue({ state: "idle" });
+
+        render(
+            <FormWrapper action="test-action" confirmDisabled={true}>
+                <input name="field" defaultValue="val" />
+            </FormWrapper>,
+        );
+
+        const submitButton = screen.getByRole("button", { name: /confirm/i });
+        expect(submitButton).toBeDisabled();
     });
 });

--- a/app/forms/tests/UpdateContactInfo.test.jsx
+++ b/app/forms/tests/UpdateContactInfo.test.jsx
@@ -6,6 +6,7 @@ const mockSubmit = jest.fn();
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
     useSubmit: () => mockSubmit,
+    useNavigation: () => ({ state: "idle" }),
     Form: ({ children, onSubmit, ...props }) => (
         <form onSubmit={onSubmit} {...props}>
             {children}

--- a/app/forms/tests/UpdatePassword.test.jsx
+++ b/app/forms/tests/UpdatePassword.test.jsx
@@ -6,6 +6,7 @@ const mockSubmit = jest.fn();
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
     useSubmit: () => mockSubmit,
+    useNavigation: () => ({ state: "idle" }),
     Form: ({ children, onSubmit, ...props }) => (
         <form onSubmit={onSubmit} {...props}>
             {children}

--- a/app/loaders/teams.js
+++ b/app/loaders/teams.js
@@ -1,3 +1,4 @@
+import { redirect } from "react-router";
 import { Query } from "node-appwrite";
 import { DateTime } from "luxon";
 import { listDocuments, readDocument } from "@/utils/databases";
@@ -64,9 +65,9 @@ export async function getUserTeams({ client, isDashboard = false }) {
             const teamPromises = teamIds.map((id) =>
                 readDocument("teams", id, [], client).catch(() => null),
             );
-            const teams = (await Promise.all(teamPromises)).filter(
-                (t) => t !== null,
-            );
+            const teams = (await Promise.all(teamPromises))
+                .filter((t) => t !== null)
+                .filter((t) => !t.archived); // Exclude archived teams from all views
 
             // 1. Batch fetch seasons for all teams
             const allTeamIds = teams.map((t) => t.$id);
@@ -369,6 +370,11 @@ export async function getTeamById({ teamId, client }) {
         }
 
         const teamData = await readDocument("teams", teamId, [], client);
+
+        // Guard: redirect if team has been archived
+        if (teamData?.archived) {
+            throw redirect("/dashboard");
+        }
 
         try {
             const { teams } = createAdminClient();

--- a/app/loaders/teams.js
+++ b/app/loaders/teams.js
@@ -376,14 +376,16 @@ export async function getTeamById({ teamId, client }) {
         let isArchiveView = false;
         let participatedSeasonIds = [];
 
-        // Guard: redirect if team has been archived
-        if (teamData?.archived) {
-            throw redirect("/dashboard");
-        }
-
         try {
             teamData = await readDocument("teams", teamId, [], client);
+            // Guard: redirect if team has been archived
+            if (teamData?.archived) {
+                throw redirect("/dashboard");
+            }
         } catch (err) {
+            // Guard: throw err if it's our redirect
+            if (err instanceof Response) throw err;
+
             // Fallback: check if they are a former player who participated in at least one season of this team
             try {
                 const { createAdminClient } = await import(
@@ -418,6 +420,10 @@ export async function getTeamById({ teamId, client }) {
                         [],
                         adminClient,
                     );
+                    // Guard: redirect if team has been archived, even in fallback
+                    if (teamData?.archived) {
+                        throw redirect("/dashboard");
+                    }
                     isArchiveView = true;
                     participatedSeasonIds = response.rows.map(
                         (r) => r.seasonId,
@@ -426,6 +432,9 @@ export async function getTeamById({ teamId, client }) {
                     throw err;
                 }
             } catch (fallbackErr) {
+                // Forward the redirect response if thrown in the fallback
+                if (fallbackErr instanceof Response) throw fallbackErr;
+
                 console.error("Access check failed for team:", fallbackErr);
                 throw err;
             }

--- a/app/routes/auth/tests/recover.test.jsx
+++ b/app/routes/auth/tests/recover.test.jsx
@@ -11,6 +11,7 @@ jest.mock("react-router", () => ({
     useNavigate: jest.fn(),
     useSearchParams: jest.fn(),
     useSubmit: jest.fn(),
+    useNavigation: () => ({ state: "idle" }),
     Form: ({ children, ...props }) => <form {...props}>{children}</form>,
 }));
 

--- a/app/routes/settings/components/tests/ResetPasswordDrawer.test.jsx
+++ b/app/routes/settings/components/tests/ResetPasswordDrawer.test.jsx
@@ -6,6 +6,7 @@ const mockSubmit = jest.fn();
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
     useSubmit: () => mockSubmit,
+    useNavigation: () => ({ state: "idle" }),
     Form: ({ children, onSubmit, ...props }) => (
         <form
             onSubmit={(e) => {

--- a/app/routes/settings/index.jsx
+++ b/app/routes/settings/index.jsx
@@ -15,7 +15,7 @@ import { logoutAction } from "@/actions/logout";
 
 import UserHeader from "@/components/UserHeader";
 import { appwriteClientContext } from "@/contexts/router";
-import { readDocument } from "@/utils/databases";
+import { listDocuments } from "@/utils/databases";
 
 import DesktopSettingsDashboard from "./components/DesktopSettingsDashboard";
 import MobileSettingsContainer from "./components/MobileSettingsContainer";
@@ -53,12 +53,33 @@ export async function loader({ context }) {
 
         // Cross-reference DB documents to filter out archived teams.
         // The Appwrite Teams API doesn't carry the `archived` flag, only the DB document does.
-        const dbDocs = await Promise.all(
-            allTeams.map((t) =>
-                readDocument("teams", t.$id, [], client).catch(() => null),
-            ),
-        );
-        const activeTeams = allTeams.filter((_, i) => !dbDocs[i]?.archived);
+        const allTeamIds = allTeams.map((t) => t.$id);
+        const unarchivedIds = new Set();
+
+        if (allTeamIds.length > 0) {
+            const batchSize = 100;
+            for (let i = 0; i < allTeamIds.length; i += batchSize) {
+                const batchIds = allTeamIds.slice(i, i + batchSize);
+                try {
+                    const result = await listDocuments(
+                        "teams",
+                        [Query.equal("$id", batchIds)],
+                        client,
+                    );
+                    if (result.rows) {
+                        result.rows.forEach((doc) => {
+                            if (!doc.archived) {
+                                unarchivedIds.add(doc.$id);
+                            }
+                        });
+                    }
+                } catch (e) {
+                    console.error("Failed to batch fetch teams", e);
+                }
+            }
+        }
+
+        const activeTeams = allTeams.filter((t) => unarchivedIds.has(t.$id));
 
         return { teams: activeTeams };
     } catch (error) {

--- a/app/routes/settings/index.jsx
+++ b/app/routes/settings/index.jsx
@@ -63,7 +63,7 @@ export async function loader({ context }) {
                 try {
                     const result = await listDocuments(
                         "teams",
-                        [Query.equal("$id", batchIds)],
+                        [Query.equal("$id", batchIds), Query.limit(100)],
                         client,
                     );
                     if (result.rows) {
@@ -75,6 +75,9 @@ export async function loader({ context }) {
                     }
                 } catch (e) {
                     console.error("Failed to batch fetch teams", e);
+                    // Fail open: assume teams are active if the DB query fails
+                    // to prevent users from losing access to teams due to transient errors.
+                    batchIds.forEach((id) => unarchivedIds.add(id));
                 }
             }
         }

--- a/app/routes/settings/index.jsx
+++ b/app/routes/settings/index.jsx
@@ -67,9 +67,20 @@ export async function loader({ context }) {
                         client,
                     );
                     if (result.rows) {
+                        const fetchedDocIds = new Set(
+                            result.rows.map((doc) => doc.$id),
+                        );
                         result.rows.forEach((doc) => {
                             if (!doc.archived) {
                                 unarchivedIds.add(doc.$id);
+                            }
+                        });
+
+                        // Fail open for any team IDs that were not returned by the DB query
+                        // (e.g. missing document or permission mismatch)
+                        batchIds.forEach((id) => {
+                            if (!fetchedDocIds.has(id)) {
+                                unarchivedIds.add(id);
                             }
                         });
                     }

--- a/app/routes/settings/index.jsx
+++ b/app/routes/settings/index.jsx
@@ -15,13 +15,15 @@ import { logoutAction } from "@/actions/logout";
 
 import UserHeader from "@/components/UserHeader";
 import { appwriteClientContext } from "@/contexts/router";
+import { readDocument } from "@/utils/databases";
 
 import DesktopSettingsDashboard from "./components/DesktopSettingsDashboard";
 import MobileSettingsContainer from "./components/MobileSettingsContainer";
 
 export async function loader({ context }) {
     try {
-        const { teams } = context.get(appwriteClientContext);
+        const client = context.get(appwriteClientContext);
+        const { teams } = client;
         // Fetch all teams with pagination to avoid only loading the first page.
         const pageSize = 100;
         const allTeams = [];
@@ -49,7 +51,16 @@ export async function loader({ context }) {
             }
         }
 
-        return { teams: allTeams };
+        // Cross-reference DB documents to filter out archived teams.
+        // The Appwrite Teams API doesn't carry the `archived` flag, only the DB document does.
+        const dbDocs = await Promise.all(
+            allTeams.map((t) =>
+                readDocument("teams", t.$id, [], client).catch(() => null),
+            ),
+        );
+        const activeTeams = allTeams.filter((_, i) => !dbDocs[i]?.archived);
+
+        return { teams: activeTeams };
     } catch (error) {
         console.error("Settings loader error:", error);
         return { teams: [] };

--- a/app/routes/settings/tests/settings.test.jsx
+++ b/app/routes/settings/tests/settings.test.jsx
@@ -31,6 +31,15 @@ jest.mock("@/actions/users", () => ({
     resetPassword: jest.fn(),
 }));
 
+jest.mock("@/utils/databases", () => ({
+    listDocuments: jest.fn().mockResolvedValue({
+        rows: [
+            { $id: "team-1", archived: false },
+            { $id: "team-101", archived: false },
+        ],
+    }),
+}));
+
 jest.mock("@/utils/appwrite/server", () => ({
     createSessionClient: jest.fn(),
 }));

--- a/app/routes/team/components/RemoveTeamDrawer.jsx
+++ b/app/routes/team/components/RemoveTeamDrawer.jsx
@@ -1,0 +1,127 @@
+import { useState, useEffect } from "react";
+import { useFetcher } from "react-router";
+
+import { Button, Stack, Text, TextInput, Alert, Group } from "@mantine/core";
+import { IconAlertTriangle, IconTrash } from "@tabler/icons-react";
+
+import DrawerContainer from "@/components/DrawerContainer";
+
+// TODO: Add archived team restore flow (admin-initiated via Appwrite console for now)
+
+/**
+ * A confirmation drawer for removing a team. The system automatically determines
+ * whether to hard-delete (empty/solo teams) or soft-archive (teams with data).
+ * The user must type the exact team name before confirming.
+ *
+ * @param {Object} props
+ * @param {boolean} props.opened - Whether the drawer is visible
+ * @param {Function} props.onClose - Callback to close the drawer
+ * @param {Object} props.team - The team object ({ $id, name })
+ */
+export default function RemoveTeamDrawer({ opened, onClose, team, players }) {
+    const fetcher = useFetcher();
+    const [confirmValue, setConfirmValue] = useState("");
+
+    const teamName = team?.name ?? "";
+    const teamId = team?.$id;
+
+    const isConfirmed = confirmValue === teamName;
+    const isSubmitting = fetcher.state !== "idle";
+
+    const hasData =
+        (team?.seasons?.length ?? 0) > 0 || (players?.length ?? 0) > 1;
+
+    // Reset input whenever the drawer opens
+    useEffect(() => {
+        if (opened) {
+            setConfirmValue("");
+        }
+    }, [opened]);
+
+    const handleSubmit = () => {
+        if (!isConfirmed || !teamId) return;
+
+        fetcher.submit(
+            { _action: "delete-team" },
+            { method: "post", action: `/team/${teamId}` },
+        );
+    };
+
+    return (
+        <DrawerContainer
+            opened={opened}
+            onClose={onClose}
+            title="Remove Team"
+            position="bottom"
+            size="auto"
+            padding="xl"
+        >
+            <Stack gap="lg">
+                <Alert
+                    icon={<IconAlertTriangle size={18} />}
+                    color="red"
+                    variant="light"
+                    title={
+                        hasData
+                            ? "This team will be archived"
+                            : "This action cannot be undone"
+                    }
+                >
+                    <Text size="sm">
+                        {hasData
+                            ? "This team has existing data (seasons, games, or players) and will be archived to preserve its history. It will disappear from your dashboard."
+                            : "This team is completely empty. It will be permanently deleted and cannot be recovered."}
+                    </Text>
+                </Alert>
+
+                <Stack gap="xs" my="md">
+                    <Text size="sm" fw={500}>
+                        Type{" "}
+                        <Text span fw={700} c="red">
+                            {teamName}
+                        </Text>{" "}
+                        to confirm:
+                    </Text>
+                    <TextInput
+                        id="remove-team-confirm-input"
+                        placeholder={teamName}
+                        value={confirmValue}
+                        onChange={(e) => setConfirmValue(e.currentTarget.value)}
+                        disabled={isSubmitting}
+                        size="md"
+                        aria-label="Type the team name to confirm removal"
+                        error={
+                            confirmValue.length > 0 && !isConfirmed
+                                ? "Team name does not match"
+                                : null
+                        }
+                    />
+                </Stack>
+
+                <Group gap="sm" wrap="nowrap">
+                    <Button
+                        variant="outline"
+                        color="gray"
+                        size="md"
+                        onClick={onClose}
+                        disabled={isSubmitting}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        id="remove-team-confirm-button"
+                        color="red"
+                        size="md"
+                        style={{ flex: 1 }}
+                        leftSection={<IconTrash size={16} />}
+                        disabled={!isConfirmed || isSubmitting}
+                        loading={isSubmitting}
+                        onClick={handleSubmit}
+                    >
+                        Remove Team
+                    </Button>
+                </Group>
+            </Stack>
+        </DrawerContainer>
+    );
+}

--- a/app/routes/team/components/RemoveTeamDrawer.jsx
+++ b/app/routes/team/components/RemoveTeamDrawer.jsx
@@ -64,13 +64,13 @@ export default function RemoveTeamDrawer({ opened, onClose, team, players }) {
                     title={
                         hasData
                             ? "This team will be archived"
-                            : "This action cannot be undone"
+                            : "Are you sure you want to remove this team?"
                     }
                 >
                     <Text size="sm">
                         {hasData
                             ? "This team has existing data (seasons, games, or players) and will be archived to preserve its history. It will disappear from your dashboard."
-                            : "This team is completely empty. It will be permanently deleted and cannot be recovered."}
+                            : "If this team is completely empty, it will be permanently deleted. Otherwise, it will be archived to preserve historical data."}
                     </Text>
                 </Alert>
 

--- a/app/routes/team/components/RemoveTeamDrawer.jsx
+++ b/app/routes/team/components/RemoveTeamDrawer.jsx
@@ -64,13 +64,13 @@ export default function RemoveTeamDrawer({ opened, onClose, team, players }) {
                     title={
                         hasData
                             ? "This team will be archived"
-                            : "Are you sure you want to remove this team?"
+                            : "This action cannot be undone"
                     }
                 >
                     <Text size="sm">
                         {hasData
                             ? "This team has existing data (seasons, games, or players) and will be archived to preserve its history. It will disappear from your dashboard."
-                            : "If this team is completely empty, it will be permanently deleted. Otherwise, it will be archived to preserve historical data."}
+                            : "This team is completely empty. It will be permanently deleted and cannot be recovered."}
                     </Text>
                 </Alert>
 

--- a/app/routes/team/components/TeamMenu.jsx
+++ b/app/routes/team/components/TeamMenu.jsx
@@ -13,6 +13,7 @@ import {
     IconSettings,
     IconShirtSport,
     IconTags,
+    IconTrash,
 } from "@tabler/icons-react";
 
 import AddTeam from "@/forms/AddTeam";
@@ -28,6 +29,7 @@ import ManageRolesDrawer from "./ManageRolesDrawer";
 import PlayerLabelsDrawer from "./PlayerLabelsDrawer";
 import PreferencesDrawer from "./PreferencesDrawer";
 import BulkJerseyNumberModal from "./BulkJerseyNumberModal";
+import RemoveTeamDrawer from "./RemoveTeamDrawer";
 
 export default function TeamMenu({ userId, team, ownerView, players }) {
     const navigate = useNavigate();
@@ -39,6 +41,8 @@ export default function TeamMenu({ userId, team, ownerView, players }) {
         { open: openPreferences, close: closePreferences },
     ] = useDisclosure(false);
     const [labelsOpened, { open: openLabels, close: closeLabels }] =
+        useDisclosure(false);
+    const [removeTeamOpened, { open: openRemoveTeam, close: closeRemoveTeam }] =
         useDisclosure(false);
 
     const { $id: teamId, name: teamName, seasons, primaryColor } = team;
@@ -185,6 +189,22 @@ export default function TeamMenu({ userId, team, ownerView, players }) {
                     : []),
             ],
         },
+        ...(ownerView
+            ? [
+                  {
+                      label: "Danger Zone",
+                      items: [
+                          {
+                              key: "remove-team",
+                              color: "red",
+                              onClick: openRemoveTeam,
+                              leftSection: <IconTrash size={18} />,
+                              content: "Remove Team",
+                          },
+                      ],
+                  },
+              ]
+            : []),
     ];
 
     return (
@@ -205,6 +225,12 @@ export default function TeamMenu({ userId, team, ownerView, players }) {
             <PlayerLabelsDrawer
                 opened={labelsOpened}
                 onClose={closeLabels}
+                team={team}
+                players={players}
+            />
+            <RemoveTeamDrawer
+                opened={removeTeamOpened}
+                onClose={closeRemoveTeam}
                 team={team}
                 players={players}
             />

--- a/app/routes/team/components/tests/RemoveTeamDrawer.test.jsx
+++ b/app/routes/team/components/tests/RemoveTeamDrawer.test.jsx
@@ -1,0 +1,170 @@
+import { useFetcher } from "react-router";
+import { render, screen, fireEvent } from "@/utils/test-utils";
+
+import RemoveTeamDrawer from "../RemoveTeamDrawer";
+
+jest.mock("react-router", () => ({
+    ...jest.requireActual("react-router"),
+    useFetcher: jest.fn(),
+}));
+
+const mockTeam = { $id: "team-123", name: "Thunder Cats" };
+
+describe("RemoveTeamDrawer", () => {
+    const mockSubmit = jest.fn();
+
+    const mockFetcher = {
+        submit: mockSubmit,
+        state: "idle",
+        data: undefined,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        useFetcher.mockReturnValue(mockFetcher);
+    });
+
+    it("renders nothing when closed", () => {
+        render(
+            <RemoveTeamDrawer
+                opened={false}
+                onClose={() => {}}
+                team={mockTeam}
+            />,
+        );
+        expect(screen.queryByText(/remove team/i)).not.toBeInTheDocument();
+    });
+
+    it("renders the drawer with team name when opened", () => {
+        render(
+            <RemoveTeamDrawer
+                opened={true}
+                onClose={() => {}}
+                team={mockTeam}
+            />,
+        );
+        expect(screen.getByText(mockTeam.name)).toBeInTheDocument();
+        expect(
+            screen.getByRole("textbox", { name: /type the team name/i }),
+        ).toBeInTheDocument();
+    });
+
+    it("keeps the confirm button disabled when input is empty", () => {
+        render(
+            <RemoveTeamDrawer
+                opened={true}
+                onClose={() => {}}
+                team={mockTeam}
+            />,
+        );
+        const button = screen.getByRole("button", { name: /remove team/i });
+        expect(button).toBeDisabled();
+    });
+
+    it("keeps the confirm button disabled when input does not match the team name", () => {
+        render(
+            <RemoveTeamDrawer
+                opened={true}
+                onClose={() => {}}
+                team={mockTeam}
+            />,
+        );
+        const input = screen.getByRole("textbox", {
+            name: /type the team name/i,
+        });
+        fireEvent.change(input, { target: { value: "thunder" } });
+
+        const button = screen.getByRole("button", { name: /remove team/i });
+        expect(button).toBeDisabled();
+    });
+
+    it("enables the confirm button when input exactly matches the team name", () => {
+        render(
+            <RemoveTeamDrawer
+                opened={true}
+                onClose={() => {}}
+                team={mockTeam}
+            />,
+        );
+        const input = screen.getByRole("textbox", {
+            name: /type the team name/i,
+        });
+        fireEvent.change(input, { target: { value: mockTeam.name } });
+
+        const button = screen.getByRole("button", { name: /remove team/i });
+        expect(button).not.toBeDisabled();
+    });
+
+    it("submits delete-team action when confirmed and button clicked", () => {
+        render(
+            <RemoveTeamDrawer
+                opened={true}
+                onClose={() => {}}
+                team={mockTeam}
+            />,
+        );
+        const input = screen.getByRole("textbox", {
+            name: /type the team name/i,
+        });
+        fireEvent.change(input, { target: { value: mockTeam.name } });
+
+        const button = screen.getByRole("button", { name: /remove team/i });
+        fireEvent.click(button);
+
+        expect(mockSubmit).toHaveBeenCalledWith(
+            { _action: "delete-team" },
+            { method: "post", action: `/team/${mockTeam.$id}` },
+        );
+    });
+
+    it("shows loading state while fetcher is submitting", () => {
+        useFetcher.mockReturnValue({ ...mockFetcher, state: "submitting" });
+
+        render(
+            <RemoveTeamDrawer
+                opened={true}
+                onClose={() => {}}
+                team={mockTeam}
+            />,
+        );
+        const input = screen.getByRole("textbox", {
+            name: /type the team name/i,
+        });
+        expect(input).toBeDisabled();
+    });
+
+    it("resets the input when the drawer is reopened", () => {
+        const { rerender } = render(
+            <RemoveTeamDrawer
+                opened={true}
+                onClose={() => {}}
+                team={mockTeam}
+            />,
+        );
+        const input = screen.getByRole("textbox", {
+            name: /type the team name/i,
+        });
+        fireEvent.change(input, { target: { value: "some text" } });
+
+        // Close then reopen
+        rerender(
+            <RemoveTeamDrawer
+                opened={false}
+                onClose={() => {}}
+                team={mockTeam}
+            />,
+        );
+        rerender(
+            <RemoveTeamDrawer
+                opened={true}
+                onClose={() => {}}
+                team={mockTeam}
+            />,
+        );
+
+        const resetInput = screen.getByRole("textbox", {
+            name: /type the team name/i,
+        });
+        expect(resetInput).toHaveValue("");
+    });
+});

--- a/app/routes/team/components/tests/RemoveTeamDrawer.test.jsx
+++ b/app/routes/team/components/tests/RemoveTeamDrawer.test.jsx
@@ -8,6 +8,17 @@ jest.mock("react-router", () => ({
     useFetcher: jest.fn(),
 }));
 
+jest.mock(
+    "@/components/DrawerContainer",
+    () =>
+        ({ children, opened, title }) =>
+            opened ? (
+                <div data-testid="drawer" data-title={title}>
+                    {children}
+                </div>
+            ) : null,
+);
+
 const mockTeam = { $id: "team-123", name: "Thunder Cats" };
 
 describe("RemoveTeamDrawer", () => {

--- a/app/routes/team/components/tests/TeamMenu.test.jsx
+++ b/app/routes/team/components/tests/TeamMenu.test.jsx
@@ -8,6 +8,7 @@ import TeamMenu from "../TeamMenu";
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
     useNavigate: jest.fn(),
+    useFetcher: () => ({ state: "idle", submit: jest.fn() }),
 }));
 
 jest.mock("@/hooks/useModal");

--- a/app/routes/team/details.jsx
+++ b/app/routes/team/details.jsx
@@ -16,7 +16,7 @@ import {
     removePlayersFromTeam,
     updatePlayerLabels,
     archiveTeam,
-    deleteTeamCompletely,
+    removeTeam,
 } from "@/actions/teams";
 import {
     invitePlayersServer,
@@ -155,7 +155,7 @@ export async function action({ request, params, context }) {
     }
 
     if (_action === "delete-team") {
-        const result = await deleteTeamCompletely({ teamId, client });
+        const result = await removeTeam({ teamId, client });
         if (result.success) return redirect("/dashboard");
         return result;
     }

--- a/app/routes/team/details.jsx
+++ b/app/routes/team/details.jsx
@@ -1,4 +1,4 @@
-import { useOutletContext } from "react-router";
+import { useOutletContext, redirect } from "react-router";
 import { Box, Container, Group, Text, Title } from "@mantine/core";
 
 import images from "@/constants/images";
@@ -14,6 +14,8 @@ import {
     updatePreferences,
     updateBulkJerseyNumbers,
     updatePlayerLabels,
+    archiveTeam,
+    deleteTeamCompletely,
 } from "@/actions/teams";
 import {
     invitePlayersServer,
@@ -142,6 +144,18 @@ export async function action({ request, params, context }) {
     }
     if (_action === "update-bulk-jersey-numbers") {
         return updateBulkJerseyNumbers({ teamId, values, client });
+    }
+
+    if (_action === "archive-team") {
+        const result = await archiveTeam({ teamId, client });
+        if (result.success) return redirect("/dashboard");
+        return result;
+    }
+
+    if (_action === "delete-team") {
+        const result = await deleteTeamCompletely({ teamId, client });
+        if (result.success) return redirect("/dashboard");
+        return result;
     }
 }
 


### PR DESCRIPTION
[![Render.com PR #229 ENV](https://img.shields.io/badge/Render.com%20PR%20%23229%20ENV-blue)](https://softball-manager-react-router-pr-229.onrender.com/)

This PR introduces several fixes and features:

1. **Form Submit Guard**: Added `loading={isSubmitting}` and disabled states to `FormWrapper` across all forms to prevent double-submissions while network requests are active.
2. **Test Updates**: Updated all form tests to use `useNavigation` mocks correctly.
3. **Backend Logic**: Implemented `archiveTeam` and `deleteTeamCompletely` functions in the backend, handling data lifecycle. Also excluded archived teams from queries across the app.
4. **UI Integration**: Built the `RemoveTeamDrawer` and integrated it into `TeamMenu`. The drawer conditionally renders warning copy depending on whether the team will be permanently deleted or just archived, providing a clear UX.
