### PR TITLE
Fix: Auto-heal missing user database documents

### DIFF
--- a/app/actions/tests/users.test.js
+++ b/app/actions/tests/users.test.js
@@ -452,6 +452,60 @@ describe("Users Actions", () => {
                 mockClient,
             );
         });
+
+        it("should self-heal and create the user document if it does not exist in the database", async () => {
+            const mockValues = {
+                firstName: "Jane",
+            };
+            const userId = "user1";
+
+            readDocument.mockRejectedValue({
+                code: 404,
+                message: "Document not found",
+            });
+
+            const testClient = {
+                tablesDB: { id: "mock-session-db" },
+                account: {
+                    get: jest.fn().mockResolvedValue({
+                        $id: userId,
+                        name: "Jane Doe",
+                        email: "jane@example.com",
+                    }),
+                },
+            };
+
+            createDocument.mockResolvedValue({
+                $id: userId,
+                userId,
+                email: "jane@example.com",
+                firstName: "Jane",
+                lastName: "Doe",
+                status: "verified",
+            });
+
+            const result = await updateUser({
+                values: mockValues,
+                userId,
+                client: testClient,
+            });
+
+            expect(createDocument).toHaveBeenCalledWith(
+                "users",
+                userId,
+                expect.objectContaining({
+                    userId,
+                    email: "jane@example.com",
+                    firstName: "Jane",
+                    lastName: "Doe",
+                    status: "verified",
+                }),
+                expect.any(Array),
+                testClient,
+            );
+            expect(result.success).toBe(true);
+            expect(result.status).toBe(204);
+        });
     });
 
     describe("updateAccountInfo", () => {

--- a/app/actions/users.js
+++ b/app/actions/users.js
@@ -169,12 +169,54 @@ export async function updateUser({ values, userId, client }) {
             }
         }
 
-        const updatedUser = await updateDocument(
-            "users",
-            userId,
-            dataToUpdate,
-            client,
-        );
+        let updatedUser;
+        if (!existingUser) {
+            // Self-heal: If the document doesn't exist, create it instead of updating.
+            // Fetch account info using the client to get name/email if not provided in values.
+            let email = values.email || "";
+            let firstName = values.firstName || "";
+            let lastName = values.lastName || "";
+
+            try {
+                const userAccount = await client.account.get();
+                email = email || userAccount.email;
+                if (userAccount.name) {
+                    const parts = userAccount.name.trim().split(" ");
+                    firstName = firstName || parts[0] || "";
+                    lastName = lastName || parts.slice(1).join(" ") || "";
+                }
+            } catch (accountErr) {
+                console.error(
+                    "updateUser - Failed to get account info before create:",
+                    accountErr,
+                );
+            }
+
+            const createResult = await createPlayer({
+                values: {
+                    email,
+                    firstName,
+                    lastName,
+                    status: "verified",
+                    ...values,
+                },
+                teamId: "self", // Passed to force permissions generation
+                userId,
+                client,
+            });
+
+            if (!createResult.success) {
+                return createResult;
+            }
+            updatedUser = createResult.response.player;
+        } else {
+            updatedUser = await updateDocument(
+                "users",
+                userId,
+                dataToUpdate,
+                client,
+            );
+        }
 
         // Check if the profile is now considered "complete"
         const isNowComplete = isUserProfileComplete(updatedUser);

--- a/app/actions/users.js
+++ b/app/actions/users.js
@@ -184,6 +184,13 @@ export async function updateUser({ values, userId, client }) {
 
             try {
                 const userAccount = await client.account.get();
+                if (userAccount?.$id && userAccount.$id !== userId) {
+                    const mismatchError = new Error(
+                        "updateUser - Auth userId mismatch; refusing to create user document.",
+                    );
+                    mismatchError.code = 400;
+                    throw mismatchError;
+                }
                 email = email || userAccount.email;
                 if (userAccount.name) {
                     const parts = userAccount.name.trim().split(" ");
@@ -191,6 +198,9 @@ export async function updateUser({ values, userId, client }) {
                     lastName = lastName || parts.slice(1).join(" ") || "";
                 }
             } catch (accountErr) {
+                if (accountErr.code === 400) {
+                    throw accountErr;
+                }
                 console.error(
                     "updateUser - Failed to get account info before create:",
                     accountErr,

--- a/app/actions/users.js
+++ b/app/actions/users.js
@@ -125,15 +125,22 @@ export async function updateUser({ values, userId, client }) {
         // Fetch the existing user to determine prior profile completion state
         let wasComplete = false;
         let existingUser = null;
+        let userDocMissing = false;
         try {
             existingUser = await readDocument("users", userId, [], client);
             wasComplete = isUserProfileComplete(existingUser);
         } catch (fetchError) {
-            // If we can't fetch the existing user, assume it was not complete
-            console.warn(
-                "Unable to fetch existing user before update:",
-                fetchError,
-            );
+            // Only treat as missing (and eligible for self-heal) on a definitive 404.
+            // All other errors (network, permissions, etc.) are re-thrown to avoid
+            // accidentally creating a duplicate document on transient failures.
+            if (fetchError?.code === 404) {
+                userDocMissing = true;
+            } else {
+                console.warn(
+                    "Unable to fetch existing user before update:",
+                    fetchError,
+                );
+            }
         }
 
         // Apply cross-field validation against existing data to maintain invariant
@@ -170,9 +177,9 @@ export async function updateUser({ values, userId, client }) {
         }
 
         let updatedUser;
-        if (!existingUser) {
-            // Self-heal: If the document doesn't exist, create it instead of updating.
-            // Fetch account info using the client to get name/email if not provided in values.
+        if (userDocMissing) {
+            // Self-heal: The document is definitively missing (404). Create it instead
+            // of updating. Fetch account info to fill in name/email if not in values.
             let email = values.email || "";
             let firstName = values.firstName || "";
             let lastName = values.lastName || "";
@@ -192,12 +199,16 @@ export async function updateUser({ values, userId, client }) {
                 );
             }
 
+            // Apply removeEmptyValues so we don't write empty strings to the new
+            // document for fields that updateUser would normally strip.
+            const cleanValues = removeEmptyValues({ values });
+
             const createResult = await createPlayer({
                 values: {
                     email,
                     firstName,
                     lastName,
-                    ...values,
+                    ...cleanValues,
                     // Ensure status is always "verified" and cannot be overridden by caller values
                     status: "verified",
                 },

--- a/app/actions/users.js
+++ b/app/actions/users.js
@@ -197,19 +197,21 @@ export async function updateUser({ values, userId, client }) {
                 );
             }
 
-            // Apply removeEmptyValues so we don't write empty strings to the new
-            // document for fields that updateUser would normally strip.
-            const cleanValues = removeEmptyValues({ values });
-
-            const createResult = await createPlayer({
+            // Apply removeEmptyValues on the final combined values so we don't write empty strings
+            // to the new document for any fields (including email, firstName, or lastName).
+            const cleanMergedValues = removeEmptyValues({
                 values: {
                     email,
                     firstName,
                     lastName,
-                    ...cleanValues,
+                    ...values,
                     // Ensure status is always "verified" and cannot be overridden by caller values
                     status: "verified",
                 },
+            });
+
+            const createResult = await createPlayer({
+                values: cleanMergedValues,
                 teamId: "self", // Passed to force permissions generation
                 userId,
                 client,

--- a/app/actions/users.js
+++ b/app/actions/users.js
@@ -197,8 +197,9 @@ export async function updateUser({ values, userId, client }) {
                     email,
                     firstName,
                     lastName,
-                    status: "verified",
                     ...values,
+                    // Ensure status is always "verified" and cannot be overridden by caller values
+                    status: "verified",
                 },
                 teamId: "self", // Passed to force permissions generation
                 userId,

--- a/app/actions/users.js
+++ b/app/actions/users.js
@@ -131,15 +131,13 @@ export async function updateUser({ values, userId, client }) {
             wasComplete = isUserProfileComplete(existingUser);
         } catch (fetchError) {
             // Only treat as missing (and eligible for self-heal) on a definitive 404.
-            // All other errors (network, permissions, etc.) are re-thrown to avoid
-            // accidentally creating a duplicate document on transient failures.
+            // All other errors (network, permissions, etc.) are re-thrown — continuing
+            // without a baseline document would break the preferred/disliked position
+            // invariant and could result in data corruption.
             if (fetchError?.code === 404) {
                 userDocMissing = true;
             } else {
-                console.warn(
-                    "Unable to fetch existing user before update:",
-                    fetchError,
-                );
+                throw fetchError;
             }
         }
 

--- a/app/actions/users.js
+++ b/app/actions/users.js
@@ -199,12 +199,13 @@ export async function updateUser({ values, userId, client }) {
 
             // Apply removeEmptyValues on the final combined values so we don't write empty strings
             // to the new document for any fields (including email, firstName, or lastName).
+            // Spread values first so that non-empty derived values will override any empty values from the caller.
             const cleanMergedValues = removeEmptyValues({
                 values: {
+                    ...values,
                     email,
                     firstName,
                     lastName,
-                    ...values,
                     // Ensure status is always "verified" and cannot be overridden by caller values
                     status: "verified",
                 },

--- a/app/loaders/tests/users.test.js
+++ b/app/loaders/tests/users.test.js
@@ -1,17 +1,25 @@
-import { listDocuments, readDocument } from "@/utils/databases";
+import { listDocuments, readDocument, createDocument } from "@/utils/databases";
 
 import {
     getUserById,
+    getOrCreateUser,
+    getInvitedUserStatus,
     getAttendanceByUserId,
     getAwardsByUserId,
     getStatsByUserId,
     getAchievementsByUserId,
 } from "../users";
+import { createAdminClient } from "@/utils/appwrite/server";
 
 // Mock dependencies
 jest.mock("@/utils/databases", () => ({
     listDocuments: jest.fn(),
     readDocument: jest.fn(),
+    createDocument: jest.fn(),
+}));
+
+jest.mock("@/utils/appwrite/server", () => ({
+    createAdminClient: jest.fn(),
 }));
 
 jest.mock("node-appwrite", () => ({
@@ -25,6 +33,18 @@ jest.mock("node-appwrite", () => ({
         or: jest.fn((queries) => `or([${queries.join(",")}])`),
         contains: jest.fn((attr, value) => `contains("${attr}", "${value}")`),
     },
+    Permission: {
+        read: jest.fn((role) => `read("${role}")`),
+        update: jest.fn((role) => `update("${role}")`),
+        delete: jest.fn((role) => `delete("${role}")`),
+    },
+    Role: {
+        any: jest.fn(() => "any"),
+        user: jest.fn((id) => `user:${id}`),
+    },
+    Users: jest.fn().mockImplementation(() => ({
+        get: jest.fn(),
+    })),
 }));
 
 describe("Users Loader", () => {
@@ -176,6 +196,144 @@ describe("Users Loader", () => {
                 mockClient,
             );
             expect(result).toEqual(mockUser);
+        });
+    });
+
+    describe("getOrCreateUser", () => {
+        it("should return user document if it exists", async () => {
+            const mockUser = { $id: "user1", name: "Test User" };
+            readDocument.mockResolvedValue(mockUser);
+
+            const result = await getOrCreateUser({
+                userId: "user1",
+                client: mockClient,
+            });
+
+            expect(readDocument).toHaveBeenCalledWith(
+                "users",
+                "user1",
+                [],
+                mockClient,
+            );
+            expect(result).toEqual(mockUser);
+        });
+
+        it("should self-heal and create user document if it does not exist", async () => {
+            readDocument.mockRejectedValue({
+                code: 404,
+                message: "Document not found",
+            });
+
+            const testClient = {
+                tablesDB: { id: "mock-session-db" },
+                account: {
+                    get: jest.fn().mockResolvedValue({
+                        $id: "user1",
+                        name: "Test User",
+                        email: "test@example.com",
+                    }),
+                },
+            };
+
+            const mockCreatedDoc = {
+                $id: "user1",
+                userId: "user1",
+                email: "test@example.com",
+                firstName: "Test",
+                lastName: "User",
+                status: "verified",
+            };
+            createDocument.mockResolvedValue(mockCreatedDoc);
+
+            const result = await getOrCreateUser({
+                userId: "user1",
+                client: testClient,
+            });
+
+            expect(createDocument).toHaveBeenCalledWith(
+                "users",
+                "user1",
+                expect.objectContaining({
+                    userId: "user1",
+                    email: "test@example.com",
+                    firstName: "Test",
+                    lastName: "User",
+                    status: "verified",
+                }),
+                expect.any(Array),
+                testClient,
+            );
+            expect(result).toEqual(mockCreatedDoc);
+        });
+    });
+
+    describe("getInvitedUserStatus", () => {
+        it("returns early if no userId provided", async () => {
+            const result = await getInvitedUserStatus({ userId: null });
+            expect(result).toEqual({
+                userDocExists: false,
+                hasPassword: false,
+            });
+        });
+
+        it("returns userDocExists and hasPassword when user document and password exist", async () => {
+            const mockUsersInstance = {
+                get: jest.fn().mockResolvedValue({
+                    email: "test@example.com",
+                    name: "Test User",
+                    passwordUpdate: "2026-07-07T12:00:00.000Z",
+                }),
+            };
+            const { Users } = require("node-appwrite");
+            Users.mockImplementation(() => mockUsersInstance);
+
+            const mockAdminClient = { account: { client: {} } };
+            createAdminClient.mockReturnValue(mockAdminClient);
+
+            readDocument.mockResolvedValue({ $id: "user123" });
+
+            const result = await getInvitedUserStatus({ userId: "user123" });
+
+            expect(createAdminClient).toHaveBeenCalled();
+            expect(mockUsersInstance.get).toHaveBeenCalledWith("user123");
+            expect(readDocument).toHaveBeenCalledWith(
+                "users",
+                "user123",
+                [],
+                mockAdminClient,
+            );
+            expect(result).toEqual({
+                userDocExists: true,
+                hasPassword: true,
+                email: "test@example.com",
+                name: "Test User",
+            });
+        });
+
+        it("returns false for userDocExists and hasPassword if read fails and passwordUpdate is empty", async () => {
+            const mockUsersInstance = {
+                get: jest.fn().mockResolvedValue({
+                    email: "test@example.com",
+                    name: "Test User",
+                    passwordUpdate: "",
+                }),
+            };
+            const { Users } = require("node-appwrite");
+            Users.mockImplementation(() => mockUsersInstance);
+
+            const mockAdminClient = { account: { client: {} } };
+            createAdminClient.mockReturnValue(mockAdminClient);
+
+            readDocument.mockRejectedValue(new Error("Not found"));
+
+            const result = await getInvitedUserStatus({ userId: "user123" });
+
+            expect(result).toEqual({
+                userDocExists: false,
+                hasPassword: false,
+                email: "test@example.com",
+                name: "Test User",
+            });
         });
     });
 

--- a/app/loaders/tests/users.test.js
+++ b/app/loaders/tests/users.test.js
@@ -265,6 +265,49 @@ describe("Users Loader", () => {
             );
             expect(result).toEqual(mockCreatedDoc);
         });
+
+        it("should re-read and return doc on 409 conflict during self-heal", async () => {
+            // Simulate: first read returns 404 (doc missing), create returns 409
+            // (another request created it concurrently), second read returns the doc.
+            const existingDoc = {
+                $id: "user1",
+                userId: "user1",
+                email: "test@example.com",
+                firstName: "Test",
+                lastName: "User",
+                status: "verified",
+            };
+
+            readDocument
+                .mockRejectedValueOnce({
+                    code: 404,
+                    message: "Document not found",
+                })
+                .mockResolvedValueOnce(existingDoc);
+
+            createDocument.mockRejectedValue({
+                code: 409,
+                message: "Document already exists",
+            });
+
+            const testClient = {
+                tablesDB: { id: "mock-session-db" },
+                account: {
+                    get: jest.fn().mockResolvedValue({
+                        $id: "user1",
+                        name: "Test User",
+                        email: "test@example.com",
+                    }),
+                },
+            };
+
+            const result = await getOrCreateUser({
+                userId: "user1",
+                client: testClient,
+            });
+
+            expect(result).toEqual(existingDoc);
+        });
     });
 
     describe("getInvitedUserStatus", () => {
@@ -277,17 +320,15 @@ describe("Users Loader", () => {
         });
 
         it("returns userDocExists and hasPassword when user document and password exist", async () => {
-            const mockUsersInstance = {
+            const mockUsers = {
                 get: jest.fn().mockResolvedValue({
                     email: "test@example.com",
                     name: "Test User",
                     passwordUpdate: "2026-07-07T12:00:00.000Z",
                 }),
             };
-            const { Users } = require("node-appwrite");
-            Users.mockImplementation(() => mockUsersInstance);
 
-            const mockAdminClient = { account: { client: {} } };
+            const mockAdminClient = { users: mockUsers };
             createAdminClient.mockReturnValue(mockAdminClient);
 
             readDocument.mockResolvedValue({ $id: "user123" });
@@ -295,7 +336,7 @@ describe("Users Loader", () => {
             const result = await getInvitedUserStatus({ userId: "user123" });
 
             expect(createAdminClient).toHaveBeenCalled();
-            expect(mockUsersInstance.get).toHaveBeenCalledWith("user123");
+            expect(mockUsers.get).toHaveBeenCalledWith("user123");
             expect(readDocument).toHaveBeenCalledWith(
                 "users",
                 "user123",
@@ -309,17 +350,15 @@ describe("Users Loader", () => {
         });
 
         it("returns false for userDocExists and hasPassword if read fails and passwordUpdate is empty", async () => {
-            const mockUsersInstance = {
+            const mockUsers = {
                 get: jest.fn().mockResolvedValue({
                     email: "test@example.com",
                     name: "Test User",
                     passwordUpdate: "",
                 }),
             };
-            const { Users } = require("node-appwrite");
-            Users.mockImplementation(() => mockUsersInstance);
 
-            const mockAdminClient = { account: { client: {} } };
+            const mockAdminClient = { users: mockUsers };
             createAdminClient.mockReturnValue(mockAdminClient);
 
             readDocument.mockRejectedValue(new Error("Not found"));

--- a/app/loaders/tests/users.test.js
+++ b/app/loaders/tests/users.test.js
@@ -3,13 +3,11 @@ import { listDocuments, readDocument, createDocument } from "@/utils/databases";
 import {
     getUserById,
     getOrCreateUser,
-    getInvitedUserStatus,
     getAttendanceByUserId,
     getAwardsByUserId,
     getStatsByUserId,
     getAchievementsByUserId,
 } from "../users";
-import { createAdminClient } from "@/utils/appwrite/server";
 
 // Mock dependencies
 jest.mock("@/utils/databases", () => ({
@@ -18,9 +16,7 @@ jest.mock("@/utils/databases", () => ({
     createDocument: jest.fn(),
 }));
 
-jest.mock("@/utils/appwrite/server", () => ({
-    createAdminClient: jest.fn(),
-}));
+jest.mock("@/utils/appwrite/server", () => ({}));
 
 jest.mock("node-appwrite", () => ({
     Query: {
@@ -307,68 +303,6 @@ describe("Users Loader", () => {
             });
 
             expect(result).toEqual(existingDoc);
-        });
-    });
-
-    describe("getInvitedUserStatus", () => {
-        it("returns early if no userId provided", async () => {
-            const result = await getInvitedUserStatus({ userId: null });
-            expect(result).toEqual({
-                userDocExists: false,
-                hasPassword: false,
-            });
-        });
-
-        it("returns userDocExists and hasPassword when user document and password exist", async () => {
-            const mockUsers = {
-                get: jest.fn().mockResolvedValue({
-                    email: "test@example.com",
-                    name: "Test User",
-                    passwordUpdate: "2026-07-07T12:00:00.000Z",
-                }),
-            };
-
-            const mockAdminClient = { users: mockUsers };
-            createAdminClient.mockReturnValue(mockAdminClient);
-
-            readDocument.mockResolvedValue({ $id: "user123" });
-
-            const result = await getInvitedUserStatus({ userId: "user123" });
-
-            expect(createAdminClient).toHaveBeenCalled();
-            expect(mockUsers.get).toHaveBeenCalledWith("user123");
-            expect(readDocument).toHaveBeenCalledWith(
-                "users",
-                "user123",
-                [],
-                mockAdminClient,
-            );
-            expect(result).toEqual({
-                userDocExists: true,
-                hasPassword: true,
-            });
-        });
-
-        it("returns false for userDocExists and hasPassword if read fails and passwordUpdate is empty", async () => {
-            const mockUsers = {
-                get: jest.fn().mockResolvedValue({
-                    email: "test@example.com",
-                    name: "Test User",
-                    passwordUpdate: "",
-                }),
-            };
-
-            const mockAdminClient = { users: mockUsers };
-            createAdminClient.mockReturnValue(mockAdminClient);
-
-            readDocument.mockRejectedValue(new Error("Not found"));
-
-            const result = await getInvitedUserStatus({ userId: "user123" });
-
-            expect(result).toEqual({
-                userDocExists: false,
-                hasPassword: false,
-            });
         });
     });
 

--- a/app/loaders/tests/users.test.js
+++ b/app/loaders/tests/users.test.js
@@ -305,8 +305,6 @@ describe("Users Loader", () => {
             expect(result).toEqual({
                 userDocExists: true,
                 hasPassword: true,
-                email: "test@example.com",
-                name: "Test User",
             });
         });
 
@@ -331,8 +329,6 @@ describe("Users Loader", () => {
             expect(result).toEqual({
                 userDocExists: false,
                 hasPassword: false,
-                email: "test@example.com",
-                name: "Test User",
             });
         });
     });

--- a/app/loaders/tests/users.test.js
+++ b/app/loaders/tests/users.test.js
@@ -262,6 +262,33 @@ describe("Users Loader", () => {
             expect(result).toEqual(mockCreatedDoc);
         });
 
+        it("should refuse self-heal and throw 400 mismatch error when Auth userId does not match the userId parameter", async () => {
+            readDocument.mockRejectedValueOnce({
+                code: 404,
+                message: "Document not found",
+            });
+
+            const testClient = {
+                tablesDB: { id: "mock-session-db" },
+                account: {
+                    get: jest.fn().mockResolvedValue({
+                        $id: "differentUser",
+                        name: "Test User",
+                        email: "test@example.com",
+                    }),
+                },
+            };
+
+            await expect(
+                getOrCreateUser({
+                    userId: "user1",
+                    client: testClient,
+                }),
+            ).rejects.toThrow(
+                "getOrCreateUser - Auth userId mismatch; refusing to create user document.",
+            );
+        });
+
         it("should re-read and return doc on 409 conflict during self-heal", async () => {
             // Simulate: first read returns 404 (doc missing), create returns 409
             // (another request created it concurrently), second read returns the doc.

--- a/app/loaders/users.js
+++ b/app/loaders/users.js
@@ -60,7 +60,9 @@ export async function getOrCreateUser({ userId, client }) {
                 "getOrCreateUser - Failed to self-heal missing user document:",
                 healError.message,
             );
-            throw e;
+            // Throw healError (the actual create failure) rather than the original
+            // 404 so callers and logs see the real reason the operation failed.
+            throw healError;
         }
     }
 }

--- a/app/loaders/users.js
+++ b/app/loaders/users.js
@@ -11,6 +11,12 @@ export async function getOrCreateUser({ userId, client }) {
     try {
         return await readDocument("users", userId, [], client);
     } catch (e) {
+        // Only attempt self-heal for missing document errors (404);
+        // re-throw permission, network, or other errors immediately.
+        if (e?.code !== 404) {
+            throw e;
+        }
+
         console.warn(
             "getOrCreateUser - User document not found, attempting self-heal:",
             e.message,
@@ -85,11 +91,11 @@ export async function getInvitedUserStatus({ userId }) {
             userAccount.passwordUpdate &&
             new Date(userAccount.passwordUpdate).getTime() > 0;
 
+        // Return only the minimal booleans needed for flow control.
+        // Avoid returning PII (email/name) from this public route loader.
         return {
             userDocExists,
             hasPassword: !!hasPassword,
-            email: userAccount.email,
-            name: userAccount.name,
         };
     } catch (error) {
         console.error(

--- a/app/loaders/users.js
+++ b/app/loaders/users.js
@@ -25,6 +25,14 @@ export async function getOrCreateUser({ userId, client }) {
             // Get user account details from Appwrite Auth
             const userAccount = await client.account.get();
 
+            if (userAccount?.$id && userAccount.$id !== userId) {
+                const mismatchError = new Error(
+                    "getOrCreateUser - Auth userId mismatch; refusing to create user document.",
+                );
+                mismatchError.code = 400;
+                throw mismatchError;
+            }
+
             const docPermissions = [
                 Permission.read(Role.any()),
                 Permission.update(Role.user(userId)),

--- a/app/loaders/users.js
+++ b/app/loaders/users.js
@@ -1,4 +1,4 @@
-import { Query, Permission, Role, Users } from "node-appwrite";
+import { Query, Permission, Role } from "node-appwrite";
 import { readDocument, listDocuments, createDocument } from "@/utils/databases";
 import { joinAchievements } from "@/utils/achievements.server";
 import { createAdminClient } from "@/utils/appwrite/server";
@@ -56,6 +56,16 @@ export async function getOrCreateUser({ userId, client }) {
                 client,
             );
         } catch (healError) {
+            // Handle race condition: if another request already created the document
+            // between our 404 and our create attempt, a 409 conflict is returned.
+            // In that case the doc now exists — re-read and return it.
+            if (healError?.code === 409) {
+                console.warn(
+                    "getOrCreateUser - Document already created by concurrent request, re-reading:",
+                    healError.message,
+                );
+                return await readDocument("users", userId, [], client);
+            }
             console.error(
                 "getOrCreateUser - Failed to self-heal missing user document:",
                 healError.message,
@@ -74,10 +84,11 @@ export async function getInvitedUserStatus({ userId }) {
 
     try {
         const adminClient = createAdminClient();
-        const users = new Users(adminClient.account.client);
 
-        // Get user account details from Appwrite Auth
-        const userAccount = await users.get(userId);
+        // Get user account details from Appwrite Auth.
+        // Use adminClient.users (the wrapper's getter) rather than constructing
+        // a Users SDK instance manually, to keep the admin client as the single source of truth.
+        const userAccount = await adminClient.users.get(userId);
 
         // Check if user document exists in database
         let userDocExists = false;

--- a/app/loaders/users.js
+++ b/app/loaders/users.js
@@ -1,9 +1,103 @@
-import { Query } from "node-appwrite";
-import { readDocument, listDocuments } from "@/utils/databases";
+import { Query, Permission, Role, Users } from "node-appwrite";
+import { readDocument, listDocuments, createDocument } from "@/utils/databases";
 import { joinAchievements } from "@/utils/achievements.server";
+import { createAdminClient } from "@/utils/appwrite/server";
 
 export async function getUserById({ userId, client }) {
     return await readDocument("users", userId, [], client);
+}
+
+export async function getOrCreateUser({ userId, client }) {
+    try {
+        return await readDocument("users", userId, [], client);
+    } catch (e) {
+        console.warn(
+            "getOrCreateUser - User document not found, attempting self-heal:",
+            e.message,
+        );
+
+        try {
+            // Get user account details from Appwrite Auth
+            const userAccount = await client.account.get();
+
+            const docPermissions = [
+                Permission.read(Role.any()),
+                Permission.update(Role.user(userId)),
+                Permission.delete(Role.user(userId)),
+            ];
+
+            let firstName = "";
+            let lastName = "";
+            if (userAccount.name) {
+                const parts = userAccount.name.trim().split(" ");
+                firstName = parts[0] || "";
+                lastName = parts.slice(1).join(" ") || "";
+            }
+
+            return await createDocument(
+                "users",
+                userId,
+                {
+                    userId,
+                    email: userAccount.email,
+                    firstName,
+                    lastName,
+                    status: "verified",
+                    preferredPositions: [],
+                    dislikedPositions: [],
+                },
+                docPermissions,
+                client,
+            );
+        } catch (healError) {
+            console.error(
+                "getOrCreateUser - Failed to self-heal missing user document:",
+                healError.message,
+            );
+            throw e;
+        }
+    }
+}
+
+export async function getInvitedUserStatus({ userId }) {
+    if (!userId) {
+        return { userDocExists: false, hasPassword: false };
+    }
+
+    try {
+        const adminClient = createAdminClient();
+        const users = new Users(adminClient.account.client);
+
+        // Get user account details from Appwrite Auth
+        const userAccount = await users.get(userId);
+
+        // Check if user document exists in database
+        let userDocExists = false;
+        try {
+            await readDocument("users", userId, [], adminClient);
+            userDocExists = true;
+        } catch (_e) {
+            userDocExists = false;
+        }
+
+        // Check if user has a password set (passwordUpdate represents password change date/time)
+        const hasPassword =
+            userAccount.passwordUpdate &&
+            new Date(userAccount.passwordUpdate).getTime() > 0;
+
+        return {
+            userDocExists,
+            hasPassword: !!hasPassword,
+            email: userAccount.email,
+            name: userAccount.name,
+        };
+    } catch (error) {
+        console.error(
+            "getInvitedUserStatus - Failed to fetch user status:",
+            error.message,
+        );
+        return { userDocExists: false, hasPassword: false };
+    }
 }
 
 export async function getAttendanceByUserId({ userId, client }) {

--- a/app/loaders/users.js
+++ b/app/loaders/users.js
@@ -1,7 +1,6 @@
 import { Query, Permission, Role } from "node-appwrite";
 import { readDocument, listDocuments, createDocument } from "@/utils/databases";
 import { joinAchievements } from "@/utils/achievements.server";
-import { createAdminClient } from "@/utils/appwrite/server";
 
 export async function getUserById({ userId, client }) {
     return await readDocument("users", userId, [], client);
@@ -74,48 +73,6 @@ export async function getOrCreateUser({ userId, client }) {
             // 404 so callers and logs see the real reason the operation failed.
             throw healError;
         }
-    }
-}
-
-export async function getInvitedUserStatus({ userId }) {
-    if (!userId) {
-        return { userDocExists: false, hasPassword: false };
-    }
-
-    try {
-        const adminClient = createAdminClient();
-
-        // Get user account details from Appwrite Auth.
-        // Use adminClient.users (the wrapper's getter) rather than constructing
-        // a Users SDK instance manually, to keep the admin client as the single source of truth.
-        const userAccount = await adminClient.users.get(userId);
-
-        // Check if user document exists in database
-        let userDocExists = false;
-        try {
-            await readDocument("users", userId, [], adminClient);
-            userDocExists = true;
-        } catch (_e) {
-            userDocExists = false;
-        }
-
-        // Check if user has a password set (passwordUpdate represents password change date/time)
-        const hasPassword =
-            userAccount.passwordUpdate &&
-            new Date(userAccount.passwordUpdate).getTime() > 0;
-
-        // Return only the minimal booleans needed for flow control.
-        // Avoid returning PII (email/name) from this public route loader.
-        return {
-            userDocExists,
-            hasPassword: !!hasPassword,
-        };
-    } catch (error) {
-        console.error(
-            "getInvitedUserStatus - Failed to fetch user status:",
-            error.message,
-        );
-        return { userDocExists: false, hasPassword: false };
     }
 }
 

--- a/app/routes/layout.jsx
+++ b/app/routes/layout.jsx
@@ -12,7 +12,7 @@ import InstallAppDrawer from "@/components/InstallAppDrawer";
 import AgreementModal from "@/components/AgreementModal";
 
 import { userContext, appwriteClientContext } from "@/contexts/router";
-import { getUserById } from "@/loaders/users";
+import { getOrCreateUser } from "@/loaders/users";
 
 import { isMobileUserAgent } from "@/utils/device";
 
@@ -27,12 +27,15 @@ export async function loader({ request, context }) {
     let userDoc = {};
     try {
         userDoc =
-            (await getUserById({
+            (await getOrCreateUser({
                 userId: accountUser.$id,
                 client: sessionClient,
             })) || {};
     } catch (e) {
-        console.error("Layout loader - Failed to fetch user doc:", e.message);
+        console.error(
+            "Layout loader - Failed to fetch or create user doc:",
+            e.message,
+        );
         // new users might not have a doc yet
     }
 

--- a/app/routes/team/accept-invite.jsx
+++ b/app/routes/team/accept-invite.jsx
@@ -30,8 +30,11 @@ export async function loader({ request }) {
     const secret = url.searchParams.get("secret");
     const membershipId = url.searchParams.get("membershipId");
 
-    // Require all invite params before hitting the admin API.
-    // Without this guard, anyone could probe for userId existence (user enumeration).
+    // Require all three invite params to be present before hitting the admin API.
+    // Note: this only checks presence, not validity. A determined attacker could
+    // supply arbitrary secret/membershipId values to probe userId status.
+    // TODO: Validate the invite against the Teams API (teamId + membershipId + userId)
+    // before calling getInvitedUserStatus to fully prevent user enumeration.
     if (!userId || !secret || !membershipId) {
         return { userDocExists: false, hasPassword: false };
     }

--- a/app/routes/team/accept-invite.jsx
+++ b/app/routes/team/accept-invite.jsx
@@ -27,6 +27,14 @@ import { getInvitedUserStatus } from "@/loaders/users";
 export async function loader({ request }) {
     const url = new URL(request.url);
     const userId = url.searchParams.get("userId");
+    const secret = url.searchParams.get("secret");
+    const membershipId = url.searchParams.get("membershipId");
+
+    // Require all invite params before hitting the admin API.
+    // Without this guard, anyone could probe for userId existence (user enumeration).
+    if (!userId || !secret || !membershipId) {
+        return { userDocExists: false, hasPassword: false };
+    }
 
     return await getInvitedUserStatus({ userId });
 }
@@ -177,7 +185,7 @@ export default function AcceptInvite({ loaderData, actionData, params }) {
                 setUserName(actionData.name);
             }
         }
-    }, [actionData, loaderData]);
+    }, [actionData]);
 
     // Validation errors
     if (!userId || !secret || !membershipId) {

--- a/app/routes/team/accept-invite.jsx
+++ b/app/routes/team/accept-invite.jsx
@@ -25,8 +25,7 @@ import { useResponseNotification } from "@/utils/showNotification";
  */
 export async function loader() {
     // No per-user status is returned here to prevent unauthenticated user enumeration.
-    // User status (hasPassword, userDocExists) is fetched inside clientAction only
-    // after Appwrite has validated the invite credentials (teamId + membershipId + userId + secret).
+    // If the invite is already confirmed, the clientAction redirects directly to /login.
     return {};
 }
 

--- a/app/routes/team/accept-invite.jsx
+++ b/app/routes/team/accept-invite.jsx
@@ -19,6 +19,7 @@ import {
 
 import { useResponseNotification } from "@/utils/showNotification";
 import { getInvitedUserStatus } from "@/loaders/users";
+import { createAdminClient } from "@/utils/appwrite/server";
 
 /**
  * Handle team invitation acceptance
@@ -58,7 +59,46 @@ export async function action({ request }) {
 
     if (_action === "check-invited-status") {
         const userId = formData.get("userId");
-        return await getInvitedUserStatus({ userId });
+        const teamId = formData.get("teamId");
+        const membershipId = formData.get("membershipId");
+
+        // Validate the request parameters are present
+        if (!userId || !teamId || !membershipId) {
+            return {
+                success: false,
+                message: "Missing required validation parameters",
+            };
+        }
+
+        try {
+            const adminClient = createAdminClient();
+            // Fetch membership details using the admin Teams API to validate caller has access
+            const membership = await adminClient.teams.getMembership(
+                teamId,
+                membershipId,
+            );
+
+            // Confirm that the membership actually belongs to the user being queried
+            if (membership.userId !== userId) {
+                return {
+                    success: false,
+                    message: "Invalid user membership association",
+                };
+            }
+
+            // Ensure the invitation is actually confirmed (completed)
+            if (!membership.confirm) {
+                return {
+                    success: false,
+                    message: "Membership is not confirmed",
+                };
+            }
+
+            return await getInvitedUserStatus({ userId });
+        } catch (error) {
+            console.error("check-invited-status validation failed:", error);
+            return { success: false, message: "Validation failed" };
+        }
     }
 
     return { success: false, message: "Unknown action" };
@@ -95,11 +135,15 @@ export async function clientAction({ request, params, serverAction }) {
         // to redirect to the team page or to login for self-healing.
         // This avoids exposing per-user status from the public loader, and runs
         // server-side via a POST fetch to prevent client-side bundling of server-only modules.
+        // It passes teamId and membershipId so the server can validate that the caller
+        // is authorized to query this userId's status.
         let userStatus = {};
         if (result?.alreadyConfirmed) {
             const statusFormData = new FormData();
             statusFormData.append("_action", "check-invited-status");
             statusFormData.append("userId", userId);
+            statusFormData.append("teamId", teamId);
+            statusFormData.append("membershipId", membershipId);
 
             try {
                 const response = await fetch(request.url, {

--- a/app/routes/team/accept-invite.jsx
+++ b/app/routes/team/accept-invite.jsx
@@ -116,7 +116,7 @@ export async function clientAction({ request, params, serverAction }) {
     return serverAction();
 }
 
-export default function AcceptInvite({ loaderData, actionData, params }) {
+export default function AcceptInvite({ actionData, params }) {
     const [searchParams] = useSearchParams();
     const [inviteAccepted, setInviteAccepted] = useState(false);
     const [userEmail, setUserEmail] = useState("");

--- a/app/routes/team/accept-invite.jsx
+++ b/app/routes/team/accept-invite.jsx
@@ -18,6 +18,7 @@ import {
 } from "@/actions/invitations";
 
 import { useResponseNotification } from "@/utils/showNotification";
+import { getInvitedUserStatus } from "@/loaders/users";
 
 /**
  * Handle team invitation acceptance
@@ -55,6 +56,11 @@ export async function action({ request }) {
         return result;
     }
 
+    if (_action === "check-invited-status") {
+        const userId = formData.get("userId");
+        return await getInvitedUserStatus({ userId });
+    }
+
     return { success: false, message: "Unknown action" };
 }
 
@@ -87,11 +93,25 @@ export async function clientAction({ request, params, serverAction }) {
         // When the invite was already confirmed, fetch the user's status here —
         // after Appwrite has validated the invite credentials — so we know whether
         // to redirect to the team page or to login for self-healing.
-        // This avoids exposing per-user status from the public loader.
+        // This avoids exposing per-user status from the public loader, and runs
+        // server-side via a POST fetch to prevent client-side bundling of server-only modules.
         let userStatus = {};
         if (result?.alreadyConfirmed) {
-            const { getInvitedUserStatus } = await import("@/loaders/users");
-            userStatus = await getInvitedUserStatus({ userId });
+            const statusFormData = new FormData();
+            statusFormData.append("_action", "check-invited-status");
+            statusFormData.append("userId", userId);
+
+            try {
+                const response = await fetch(request.url, {
+                    method: "POST",
+                    body: statusFormData,
+                });
+                if (response.ok) {
+                    userStatus = await response.json();
+                }
+            } catch (err) {
+                console.error("Failed to check invited user status:", err);
+            }
         }
 
         return {

--- a/app/routes/team/accept-invite.jsx
+++ b/app/routes/team/accept-invite.jsx
@@ -138,6 +138,10 @@ export default function AcceptInvite({ loaderData, actionData, params }) {
                 // Self-healing: they have a password, but database doc is missing.
                 // Redirect to login where they will log in and self-heal automatically.
                 navigate("/login");
+            } else {
+                // Unhandled already-confirmed state (no password or unknown);
+                // fall back to login so the user is not stuck indefinitely.
+                navigate("/login");
             }
         }
     }, [actionData, loaderData, params.teamId, navigate]);
@@ -168,13 +172,9 @@ export default function AcceptInvite({ loaderData, actionData, params }) {
             setInviteAccepted(true);
             if (actionData.email) {
                 setUserEmail(actionData.email);
-            } else if (loaderData?.email) {
-                setUserEmail(loaderData.email);
             }
             if (actionData.name) {
                 setUserName(actionData.name);
-            } else if (loaderData?.name) {
-                setUserName(loaderData.name);
             }
         }
     }, [actionData, loaderData]);

--- a/app/routes/team/accept-invite.jsx
+++ b/app/routes/team/accept-invite.jsx
@@ -18,8 +18,6 @@ import {
 } from "@/actions/invitations";
 
 import { useResponseNotification } from "@/utils/showNotification";
-import { getInvitedUserStatus } from "@/loaders/users";
-import { createAdminClient } from "@/utils/appwrite/server";
 
 /**
  * Handle team invitation acceptance
@@ -57,50 +55,6 @@ export async function action({ request }) {
         return result;
     }
 
-    if (_action === "check-invited-status") {
-        const userId = formData.get("userId");
-        const teamId = formData.get("teamId");
-        const membershipId = formData.get("membershipId");
-
-        // Validate the request parameters are present
-        if (!userId || !teamId || !membershipId) {
-            return {
-                success: false,
-                message: "Missing required validation parameters",
-            };
-        }
-
-        try {
-            const adminClient = createAdminClient();
-            // Fetch membership details using the admin Teams API to validate caller has access
-            const membership = await adminClient.teams.getMembership(
-                teamId,
-                membershipId,
-            );
-
-            // Confirm that the membership actually belongs to the user being queried
-            if (membership.userId !== userId) {
-                return {
-                    success: false,
-                    message: "Invalid user membership association",
-                };
-            }
-
-            // Ensure the invitation is actually confirmed (completed)
-            if (!membership.confirm) {
-                return {
-                    success: false,
-                    message: "Membership is not confirmed",
-                };
-            }
-
-            return await getInvitedUserStatus({ userId });
-        } catch (error) {
-            console.error("check-invited-status validation failed:", error);
-            return { success: false, message: "Validation failed" };
-        }
-    }
-
     return { success: false, message: "Unknown action" };
 }
 
@@ -130,37 +84,8 @@ export async function clientAction({ request, params, serverAction }) {
             result.success === true &&
             result.alreadyConfirmed !== true;
 
-        // When the invite was already confirmed, fetch the user's status here —
-        // after Appwrite has validated the invite credentials — so we know whether
-        // to redirect to the team page or to login for self-healing.
-        // This avoids exposing per-user status from the public loader, and runs
-        // server-side via a POST fetch to prevent client-side bundling of server-only modules.
-        // It passes teamId and membershipId so the server can validate that the caller
-        // is authorized to query this userId's status.
-        let userStatus = {};
-        if (result?.alreadyConfirmed) {
-            const statusFormData = new FormData();
-            statusFormData.append("_action", "check-invited-status");
-            statusFormData.append("userId", userId);
-            statusFormData.append("teamId", teamId);
-            statusFormData.append("membershipId", membershipId);
-
-            try {
-                const response = await fetch(request.url, {
-                    method: "POST",
-                    body: statusFormData,
-                });
-                if (response.ok) {
-                    userStatus = await response.json();
-                }
-            } catch (err) {
-                console.error("Failed to check invited user status:", err);
-            }
-        }
-
         return {
             ...result,
-            ...userStatus,
             ...(isNewlyAccepted
                 ? {
                       event: {
@@ -204,23 +129,14 @@ export default function AcceptInvite({ actionData, params }) {
     }, [userId, secret, membershipId, inviteAccepted]);
 
     // Redirect conditionally if invitation was already confirmed.
-    // hasPassword and userDocExists are now returned from clientAction (not loaderData)
-    // so this data is only available after Appwrite validates the invite credentials.
+    // If invitation is already confirmed, redirect directly to /login to prevent
+    // user status enumeration. If user is logged in, they will be redirected to
+    // dashboard/profile; otherwise they can log in to self-heal.
     useEffect(() => {
         if (actionData?.alreadyConfirmed) {
-            if (actionData?.hasPassword && actionData?.userDocExists) {
-                navigate(`/team/${params.teamId}`);
-            } else if (actionData?.hasPassword && !actionData?.userDocExists) {
-                // Self-healing: they have a password, but database doc is missing.
-                // Redirect to login where they will log in and self-heal automatically.
-                navigate("/login");
-            } else {
-                // Unhandled already-confirmed state (no password or unknown);
-                // fall back to login so the user is not stuck indefinitely.
-                navigate("/login");
-            }
+            navigate("/login");
         }
-    }, [actionData, params.teamId, navigate]);
+    }, [actionData, navigate]);
 
     // Auto-subscribe to team notifications if global notifications are enabled
     const { pushTargetId, subscribeToTeam } = useNotifications();

--- a/app/routes/team/accept-invite.jsx
+++ b/app/routes/team/accept-invite.jsx
@@ -18,28 +18,16 @@ import {
 } from "@/actions/invitations";
 
 import { useResponseNotification } from "@/utils/showNotification";
-import { getInvitedUserStatus } from "@/loaders/users";
 
 /**
  * Handle team invitation acceptance
  * This route is accessed when users click the invitation link in their email
  */
-export async function loader({ request }) {
-    const url = new URL(request.url);
-    const userId = url.searchParams.get("userId");
-    const secret = url.searchParams.get("secret");
-    const membershipId = url.searchParams.get("membershipId");
-
-    // Require all three invite params to be present before hitting the admin API.
-    // Note: this only checks presence, not validity. A determined attacker could
-    // supply arbitrary secret/membershipId values to probe userId status.
-    // TODO: Validate the invite against the Teams API (teamId + membershipId + userId)
-    // before calling getInvitedUserStatus to fully prevent user enumeration.
-    if (!userId || !secret || !membershipId) {
-        return { userDocExists: false, hasPassword: false };
-    }
-
-    return await getInvitedUserStatus({ userId });
+export async function loader() {
+    // No per-user status is returned here to prevent unauthenticated user enumeration.
+    // User status (hasPassword, userDocExists) is fetched inside clientAction only
+    // after Appwrite has validated the invite credentials (teamId + membershipId + userId + secret).
+    return {};
 }
 
 export async function action({ request }) {
@@ -96,8 +84,19 @@ export async function clientAction({ request, params, serverAction }) {
             result.success === true &&
             result.alreadyConfirmed !== true;
 
+        // When the invite was already confirmed, fetch the user's status here —
+        // after Appwrite has validated the invite credentials — so we know whether
+        // to redirect to the team page or to login for self-healing.
+        // This avoids exposing per-user status from the public loader.
+        let userStatus = {};
+        if (result?.alreadyConfirmed) {
+            const { getInvitedUserStatus } = await import("@/loaders/users");
+            userStatus = await getInvitedUserStatus({ userId });
+        }
+
         return {
             ...result,
+            ...userStatus,
             ...(isNewlyAccepted
                 ? {
                       event: {
@@ -140,12 +139,14 @@ export default function AcceptInvite({ loaderData, actionData, params }) {
         }
     }, [userId, secret, membershipId, inviteAccepted]);
 
-    // Redirect conditionally if invitation was already confirmed
+    // Redirect conditionally if invitation was already confirmed.
+    // hasPassword and userDocExists are now returned from clientAction (not loaderData)
+    // so this data is only available after Appwrite validates the invite credentials.
     useEffect(() => {
         if (actionData?.alreadyConfirmed) {
-            if (loaderData?.hasPassword && loaderData?.userDocExists) {
+            if (actionData?.hasPassword && actionData?.userDocExists) {
                 navigate(`/team/${params.teamId}`);
-            } else if (loaderData?.hasPassword && !loaderData?.userDocExists) {
+            } else if (actionData?.hasPassword && !actionData?.userDocExists) {
                 // Self-healing: they have a password, but database doc is missing.
                 // Redirect to login where they will log in and self-heal automatically.
                 navigate("/login");
@@ -155,7 +156,7 @@ export default function AcceptInvite({ loaderData, actionData, params }) {
                 navigate("/login");
             }
         }
-    }, [actionData, loaderData, params.teamId, navigate]);
+    }, [actionData, params.teamId, navigate]);
 
     // Auto-subscribe to team notifications if global notifications are enabled
     const { pushTargetId, subscribeToTeam } = useNotifications();

--- a/app/routes/team/accept-invite.jsx
+++ b/app/routes/team/accept-invite.jsx
@@ -18,14 +18,17 @@ import {
 } from "@/actions/invitations";
 
 import { useResponseNotification } from "@/utils/showNotification";
+import { getInvitedUserStatus } from "@/loaders/users";
 
 /**
  * Handle team invitation acceptance
  * This route is accessed when users click the invitation link in their email
  */
-export async function loader() {
-    // Just return empty - we'll handle everything in clientAction
-    return {};
+export async function loader({ request }) {
+    const url = new URL(request.url);
+    const userId = url.searchParams.get("userId");
+
+    return await getInvitedUserStatus({ userId });
 }
 
 export async function action({ request }) {
@@ -103,7 +106,7 @@ export async function clientAction({ request, params, serverAction }) {
     return serverAction();
 }
 
-export default function AcceptInvite({ actionData, params }) {
+export default function AcceptInvite({ loaderData, actionData, params }) {
     const [searchParams] = useSearchParams();
     const [inviteAccepted, setInviteAccepted] = useState(false);
     const [userEmail, setUserEmail] = useState("");
@@ -126,12 +129,18 @@ export default function AcceptInvite({ actionData, params }) {
         }
     }, [userId, secret, membershipId, inviteAccepted]);
 
-    // Redirect to team page if invitation was already confirmed
+    // Redirect conditionally if invitation was already confirmed
     useEffect(() => {
         if (actionData?.alreadyConfirmed) {
-            navigate(`/team/${params.teamId}`);
+            if (loaderData?.hasPassword && loaderData?.userDocExists) {
+                navigate(`/team/${params.teamId}`);
+            } else if (loaderData?.hasPassword && !loaderData?.userDocExists) {
+                // Self-healing: they have a password, but database doc is missing.
+                // Redirect to login where they will log in and self-heal automatically.
+                navigate("/login");
+            }
         }
-    }, [actionData, params.teamId, navigate]);
+    }, [actionData, loaderData, params.teamId, navigate]);
 
     // Auto-subscribe to team notifications if global notifications are enabled
     const { pushTargetId, subscribeToTeam } = useNotifications();
@@ -159,12 +168,16 @@ export default function AcceptInvite({ actionData, params }) {
             setInviteAccepted(true);
             if (actionData.email) {
                 setUserEmail(actionData.email);
+            } else if (loaderData?.email) {
+                setUserEmail(loaderData.email);
             }
             if (actionData.name) {
                 setUserName(actionData.name);
+            } else if (loaderData?.name) {
+                setUserName(loaderData.name);
             }
         }
-    }, [actionData]);
+    }, [actionData, loaderData]);
 
     // Validation errors
     if (!userId || !secret || !membershipId) {

--- a/app/routes/team/tests/accept-invite.test.js
+++ b/app/routes/team/tests/accept-invite.test.js
@@ -8,12 +8,6 @@ import {
 } from "@/actions/invitations";
 
 import AcceptInvite, { loader, action, clientAction } from "../accept-invite";
-import { getInvitedUserStatus } from "@/loaders/users";
-import { createAdminClient } from "@/utils/appwrite/server";
-
-jest.mock("@/utils/appwrite/server", () => ({
-    createAdminClient: jest.fn(),
-}));
 
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
@@ -24,10 +18,6 @@ jest.mock("react-router", () => ({
             {children}
         </form>
     ),
-}));
-
-jest.mock("@/loaders/users", () => ({
-    getInvitedUserStatus: jest.fn(),
 }));
 
 jest.mock("@/actions/invitations");
@@ -59,10 +49,9 @@ describe("AcceptInvite Route", () => {
     });
 
     describe("loader", () => {
-        it("returns an empty object without calling getInvitedUserStatus", async () => {
+        it("returns an empty object", async () => {
             const result = await loader();
 
-            expect(getInvitedUserStatus).not.toHaveBeenCalled();
             expect(result).toEqual({});
         });
     });
@@ -84,107 +73,6 @@ describe("AcceptInvite Route", () => {
                 email: "test@test.com",
                 password: "newpassword123",
                 name: "Test User",
-            });
-        });
-
-        it("calls getInvitedUserStatus for check-invited-status action when membership is valid and confirmed", async () => {
-            const formData = new FormData();
-            formData.append("_action", "check-invited-status");
-            formData.append("userId", "user123");
-            formData.append("teamId", "team123");
-            formData.append("membershipId", "mem123");
-
-            const request = { formData: () => Promise.resolve(formData) };
-            getInvitedUserStatus.mockResolvedValue({
-                userDocExists: true,
-                hasPassword: true,
-            });
-
-            const mockGetMembership = jest.fn().mockResolvedValue({
-                userId: "user123",
-                confirm: true,
-            });
-            createAdminClient.mockReturnValue({
-                teams: {
-                    getMembership: mockGetMembership,
-                },
-            });
-
-            const result = await action({ request });
-
-            expect(mockGetMembership).toHaveBeenCalledWith("team123", "mem123");
-            expect(getInvitedUserStatus).toHaveBeenCalledWith({
-                userId: "user123",
-            });
-            expect(result).toEqual({
-                userDocExists: true,
-                hasPassword: true,
-            });
-        });
-
-        it("fails to check status when validation parameters are missing", async () => {
-            const formData = new FormData();
-            formData.append("_action", "check-invited-status");
-            formData.append("userId", "user123");
-
-            const request = { formData: () => Promise.resolve(formData) };
-            const result = await action({ request });
-
-            expect(result).toEqual({
-                success: false,
-                message: "Missing required validation parameters",
-            });
-        });
-
-        it("fails to check status when membership belongs to a different user", async () => {
-            const formData = new FormData();
-            formData.append("_action", "check-invited-status");
-            formData.append("userId", "user123");
-            formData.append("teamId", "team123");
-            formData.append("membershipId", "mem123");
-
-            const request = { formData: () => Promise.resolve(formData) };
-            const mockGetMembership = jest.fn().mockResolvedValue({
-                userId: "different_user",
-                confirm: true,
-            });
-            createAdminClient.mockReturnValue({
-                teams: {
-                    getMembership: mockGetMembership,
-                },
-            });
-
-            const result = await action({ request });
-
-            expect(result).toEqual({
-                success: false,
-                message: "Invalid user membership association",
-            });
-        });
-
-        it("fails to check status when membership is not confirmed", async () => {
-            const formData = new FormData();
-            formData.append("_action", "check-invited-status");
-            formData.append("userId", "user123");
-            formData.append("teamId", "team123");
-            formData.append("membershipId", "mem123");
-
-            const request = { formData: () => Promise.resolve(formData) };
-            const mockGetMembership = jest.fn().mockResolvedValue({
-                userId: "user123",
-                confirm: false,
-            });
-            createAdminClient.mockReturnValue({
-                teams: {
-                    getMembership: mockGetMembership,
-                },
-            });
-
-            const result = await action({ request });
-
-            expect(result).toEqual({
-                success: false,
-                message: "Membership is not confirmed",
             });
         });
 
@@ -243,69 +131,6 @@ describe("AcceptInvite Route", () => {
             await clientAction({ request, serverAction, params: {} });
             expect(serverAction).toHaveBeenCalled();
         });
-
-        it("calls server action via fetch and returns status on alreadyConfirmed success", async () => {
-            const formData = new FormData();
-            formData.append("_action", "accept-invite");
-            formData.append("membershipId", "mem123");
-            formData.append("userId", "user123");
-            formData.append("secret", "secret123");
-
-            const request = {
-                clone: () => ({
-                    formData: () => Promise.resolve(formData),
-                }),
-                formData: () => Promise.resolve(formData),
-                url: "http://localhost/team/accept-invite",
-            };
-            const params = { teamId: "team123" };
-
-            acceptTeamInvitation.mockResolvedValue({
-                success: true,
-                alreadyConfirmed: true,
-            });
-
-            const mockResponseJson = {
-                userDocExists: true,
-                hasPassword: true,
-            };
-
-            const mockFetch = jest.fn().mockResolvedValue({
-                ok: true,
-                json: () => Promise.resolve(mockResponseJson),
-            });
-            global.fetch = mockFetch;
-
-            const result = await clientAction({ request, params });
-
-            expect(acceptTeamInvitation).toHaveBeenCalledWith({
-                teamId: "team123",
-                membershipId: "mem123",
-                userId: "user123",
-                secret: "secret123",
-            });
-            expect(mockFetch).toHaveBeenCalledWith(
-                "http://localhost/team/accept-invite",
-                expect.objectContaining({
-                    method: "POST",
-                    body: expect.any(FormData),
-                }),
-            );
-
-            // Verify the FormData sent to fetch has correct intent and validation params
-            const fetchedFormData = mockFetch.mock.calls[0][1].body;
-            expect(fetchedFormData.get("_action")).toBe("check-invited-status");
-            expect(fetchedFormData.get("userId")).toBe("user123");
-            expect(fetchedFormData.get("teamId")).toBe("team123");
-            expect(fetchedFormData.get("membershipId")).toBe("mem123");
-
-            expect(result).toEqual({
-                success: true,
-                alreadyConfirmed: true,
-                userDocExists: true,
-                hasPassword: true,
-            });
-        });
     });
 
     describe("Component", () => {
@@ -350,27 +175,9 @@ describe("AcceptInvite Route", () => {
             ).toBeInTheDocument();
         });
 
-        it("redirects to team page if already confirmed and user has password and doc exists", () => {
+        it("redirects to login if already confirmed", () => {
             const actionData = {
                 alreadyConfirmed: true,
-                hasPassword: true,
-                userDocExists: true,
-            };
-            render(
-                <AcceptInvite
-                    params={{ teamId: "team123" }}
-                    actionData={actionData}
-                />,
-            );
-
-            expect(mockNavigate).toHaveBeenCalledWith("/team/team123");
-        });
-
-        it("redirects to login if already confirmed but user doc is missing", () => {
-            const actionData = {
-                alreadyConfirmed: true,
-                hasPassword: true,
-                userDocExists: false,
             };
             render(
                 <AcceptInvite

--- a/app/routes/team/tests/accept-invite.test.js
+++ b/app/routes/team/tests/accept-invite.test.js
@@ -62,7 +62,7 @@ describe("AcceptInvite Route", () => {
             getInvitedUserStatus.mockResolvedValue(mockStatus);
 
             const request = new Request(
-                "http://localhost/team/accept-invite?userId=user123",
+                "http://localhost/team/accept-invite?userId=user123&secret=abc&membershipId=mem456",
             );
             const result = await loader({ request });
 
@@ -70,6 +70,19 @@ describe("AcceptInvite Route", () => {
                 userId: "user123",
             });
             expect(result).toEqual(mockStatus);
+        });
+
+        it("returns empty status without calling getInvitedUserStatus when invite params are missing", async () => {
+            const request = new Request(
+                "http://localhost/team/accept-invite?userId=user123",
+            );
+            const result = await loader({ request });
+
+            expect(getInvitedUserStatus).not.toHaveBeenCalled();
+            expect(result).toEqual({
+                userDocExists: false,
+                hasPassword: false,
+            });
         });
     });
 

--- a/app/routes/team/tests/accept-invite.test.js
+++ b/app/routes/team/tests/accept-invite.test.js
@@ -9,6 +9,11 @@ import {
 
 import AcceptInvite, { loader, action, clientAction } from "../accept-invite";
 import { getInvitedUserStatus } from "@/loaders/users";
+import { createAdminClient } from "@/utils/appwrite/server";
+
+jest.mock("@/utils/appwrite/server", () => ({
+    createAdminClient: jest.fn(),
+}));
 
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
@@ -82,10 +87,12 @@ describe("AcceptInvite Route", () => {
             });
         });
 
-        it("calls getInvitedUserStatus for check-invited-status action", async () => {
+        it("calls getInvitedUserStatus for check-invited-status action when membership is valid and confirmed", async () => {
             const formData = new FormData();
             formData.append("_action", "check-invited-status");
             formData.append("userId", "user123");
+            formData.append("teamId", "team123");
+            formData.append("membershipId", "mem123");
 
             const request = { formData: () => Promise.resolve(formData) };
             getInvitedUserStatus.mockResolvedValue({
@@ -93,14 +100,91 @@ describe("AcceptInvite Route", () => {
                 hasPassword: true,
             });
 
+            const mockGetMembership = jest.fn().mockResolvedValue({
+                userId: "user123",
+                confirm: true,
+            });
+            createAdminClient.mockReturnValue({
+                teams: {
+                    getMembership: mockGetMembership,
+                },
+            });
+
             const result = await action({ request });
 
+            expect(mockGetMembership).toHaveBeenCalledWith("team123", "mem123");
             expect(getInvitedUserStatus).toHaveBeenCalledWith({
                 userId: "user123",
             });
             expect(result).toEqual({
                 userDocExists: true,
                 hasPassword: true,
+            });
+        });
+
+        it("fails to check status when validation parameters are missing", async () => {
+            const formData = new FormData();
+            formData.append("_action", "check-invited-status");
+            formData.append("userId", "user123");
+
+            const request = { formData: () => Promise.resolve(formData) };
+            const result = await action({ request });
+
+            expect(result).toEqual({
+                success: false,
+                message: "Missing required validation parameters",
+            });
+        });
+
+        it("fails to check status when membership belongs to a different user", async () => {
+            const formData = new FormData();
+            formData.append("_action", "check-invited-status");
+            formData.append("userId", "user123");
+            formData.append("teamId", "team123");
+            formData.append("membershipId", "mem123");
+
+            const request = { formData: () => Promise.resolve(formData) };
+            const mockGetMembership = jest.fn().mockResolvedValue({
+                userId: "different_user",
+                confirm: true,
+            });
+            createAdminClient.mockReturnValue({
+                teams: {
+                    getMembership: mockGetMembership,
+                },
+            });
+
+            const result = await action({ request });
+
+            expect(result).toEqual({
+                success: false,
+                message: "Invalid user membership association",
+            });
+        });
+
+        it("fails to check status when membership is not confirmed", async () => {
+            const formData = new FormData();
+            formData.append("_action", "check-invited-status");
+            formData.append("userId", "user123");
+            formData.append("teamId", "team123");
+            formData.append("membershipId", "mem123");
+
+            const request = { formData: () => Promise.resolve(formData) };
+            const mockGetMembership = jest.fn().mockResolvedValue({
+                userId: "user123",
+                confirm: false,
+            });
+            createAdminClient.mockReturnValue({
+                teams: {
+                    getMembership: mockGetMembership,
+                },
+            });
+
+            const result = await action({ request });
+
+            expect(result).toEqual({
+                success: false,
+                message: "Membership is not confirmed",
             });
         });
 
@@ -208,10 +292,12 @@ describe("AcceptInvite Route", () => {
                 }),
             );
 
-            // Verify the FormData sent to fetch has correct intent
+            // Verify the FormData sent to fetch has correct intent and validation params
             const fetchedFormData = mockFetch.mock.calls[0][1].body;
             expect(fetchedFormData.get("_action")).toBe("check-invited-status");
             expect(fetchedFormData.get("userId")).toBe("user123");
+            expect(fetchedFormData.get("teamId")).toBe("team123");
+            expect(fetchedFormData.get("membershipId")).toBe("mem123");
 
             expect(result).toEqual({
                 success: true,

--- a/app/routes/team/tests/accept-invite.test.js
+++ b/app/routes/team/tests/accept-invite.test.js
@@ -54,35 +54,11 @@ describe("AcceptInvite Route", () => {
     });
 
     describe("loader", () => {
-        it("delegates invite status check to getInvitedUserStatus", async () => {
-            const mockStatus = {
-                userDocExists: true,
-                hasPassword: true,
-            };
-            getInvitedUserStatus.mockResolvedValue(mockStatus);
-
-            const request = new Request(
-                "http://localhost/team/accept-invite?userId=user123&secret=abc&membershipId=mem456",
-            );
-            const result = await loader({ request });
-
-            expect(getInvitedUserStatus).toHaveBeenCalledWith({
-                userId: "user123",
-            });
-            expect(result).toEqual(mockStatus);
-        });
-
-        it("returns empty status without calling getInvitedUserStatus when invite params are missing", async () => {
-            const request = new Request(
-                "http://localhost/team/accept-invite?userId=user123",
-            );
-            const result = await loader({ request });
+        it("returns an empty object without calling getInvitedUserStatus", async () => {
+            const result = await loader();
 
             expect(getInvitedUserStatus).not.toHaveBeenCalled();
-            expect(result).toEqual({
-                userDocExists: false,
-                hasPassword: false,
-            });
+            expect(result).toEqual({});
         });
     });
 
@@ -206,13 +182,15 @@ describe("AcceptInvite Route", () => {
         });
 
         it("redirects to team page if already confirmed and user has password and doc exists", () => {
-            const actionData = { alreadyConfirmed: true };
-            const loaderData = { hasPassword: true, userDocExists: true };
+            const actionData = {
+                alreadyConfirmed: true,
+                hasPassword: true,
+                userDocExists: true,
+            };
             render(
                 <AcceptInvite
                     params={{ teamId: "team123" }}
                     actionData={actionData}
-                    loaderData={loaderData}
                 />,
             );
 
@@ -220,13 +198,15 @@ describe("AcceptInvite Route", () => {
         });
 
         it("redirects to login if already confirmed but user doc is missing", () => {
-            const actionData = { alreadyConfirmed: true };
-            const loaderData = { hasPassword: true, userDocExists: false };
+            const actionData = {
+                alreadyConfirmed: true,
+                hasPassword: true,
+                userDocExists: false,
+            };
             render(
                 <AcceptInvite
                     params={{ teamId: "team123" }}
                     actionData={actionData}
-                    loaderData={loaderData}
                 />,
             );
 

--- a/app/routes/team/tests/accept-invite.test.js
+++ b/app/routes/team/tests/accept-invite.test.js
@@ -7,7 +7,8 @@ import {
     setPasswordForInvitedUser,
 } from "@/actions/invitations";
 
-import AcceptInvite, { action, clientAction } from "../accept-invite";
+import AcceptInvite, { loader, action, clientAction } from "../accept-invite";
+import { getInvitedUserStatus } from "@/loaders/users";
 
 jest.mock("react-router", () => ({
     ...jest.requireActual("react-router"),
@@ -18,6 +19,10 @@ jest.mock("react-router", () => ({
             {children}
         </form>
     ),
+}));
+
+jest.mock("@/loaders/users", () => ({
+    getInvitedUserStatus: jest.fn(),
 }));
 
 jest.mock("@/actions/invitations");
@@ -45,6 +50,28 @@ describe("AcceptInvite Route", () => {
         // Mock document.getElementById().requestSubmit()
         document.getElementById = jest.fn().mockReturnValue({
             requestSubmit: jest.fn(),
+        });
+    });
+
+    describe("loader", () => {
+        it("delegates invite status check to getInvitedUserStatus", async () => {
+            const mockStatus = {
+                userDocExists: true,
+                hasPassword: true,
+                email: "test@example.com",
+                name: "Test User",
+            };
+            getInvitedUserStatus.mockResolvedValue(mockStatus);
+
+            const request = new Request(
+                "http://localhost/team/accept-invite?userId=user123",
+            );
+            const result = await loader({ request });
+
+            expect(getInvitedUserStatus).toHaveBeenCalledWith({
+                userId: "user123",
+            });
+            expect(result).toEqual(mockStatus);
         });
     });
 
@@ -167,16 +194,32 @@ describe("AcceptInvite Route", () => {
             ).toBeInTheDocument();
         });
 
-        it("redirects to team page if already confirmed", () => {
+        it("redirects to team page if already confirmed and user has password and doc exists", () => {
             const actionData = { alreadyConfirmed: true };
+            const loaderData = { hasPassword: true, userDocExists: true };
             render(
                 <AcceptInvite
                     params={{ teamId: "team123" }}
                     actionData={actionData}
+                    loaderData={loaderData}
                 />,
             );
 
             expect(mockNavigate).toHaveBeenCalledWith("/team/team123");
+        });
+
+        it("redirects to login if already confirmed but user doc is missing", () => {
+            const actionData = { alreadyConfirmed: true };
+            const loaderData = { hasPassword: true, userDocExists: false };
+            render(
+                <AcceptInvite
+                    params={{ teamId: "team123" }}
+                    actionData={actionData}
+                    loaderData={loaderData}
+                />,
+            );
+
+            expect(mockNavigate).toHaveBeenCalledWith("/login");
         });
 
         it("subscribes to team notifications on success", async () => {

--- a/app/routes/team/tests/accept-invite.test.js
+++ b/app/routes/team/tests/accept-invite.test.js
@@ -58,8 +58,6 @@ describe("AcceptInvite Route", () => {
             const mockStatus = {
                 userDocExists: true,
                 hasPassword: true,
-                email: "test@example.com",
-                name: "Test User",
             };
             getInvitedUserStatus.mockResolvedValue(mockStatus);
 

--- a/app/routes/team/tests/accept-invite.test.js
+++ b/app/routes/team/tests/accept-invite.test.js
@@ -82,6 +82,28 @@ describe("AcceptInvite Route", () => {
             });
         });
 
+        it("calls getInvitedUserStatus for check-invited-status action", async () => {
+            const formData = new FormData();
+            formData.append("_action", "check-invited-status");
+            formData.append("userId", "user123");
+
+            const request = { formData: () => Promise.resolve(formData) };
+            getInvitedUserStatus.mockResolvedValue({
+                userDocExists: true,
+                hasPassword: true,
+            });
+
+            const result = await action({ request });
+
+            expect(getInvitedUserStatus).toHaveBeenCalledWith({
+                userId: "user123",
+            });
+            expect(result).toEqual({
+                userDocExists: true,
+                hasPassword: true,
+            });
+        });
+
         it("returns error for unknown action", async () => {
             const formData = new FormData();
             formData.append("_action", "invalid");
@@ -136,6 +158,67 @@ describe("AcceptInvite Route", () => {
 
             await clientAction({ request, serverAction, params: {} });
             expect(serverAction).toHaveBeenCalled();
+        });
+
+        it("calls server action via fetch and returns status on alreadyConfirmed success", async () => {
+            const formData = new FormData();
+            formData.append("_action", "accept-invite");
+            formData.append("membershipId", "mem123");
+            formData.append("userId", "user123");
+            formData.append("secret", "secret123");
+
+            const request = {
+                clone: () => ({
+                    formData: () => Promise.resolve(formData),
+                }),
+                formData: () => Promise.resolve(formData),
+                url: "http://localhost/team/accept-invite",
+            };
+            const params = { teamId: "team123" };
+
+            acceptTeamInvitation.mockResolvedValue({
+                success: true,
+                alreadyConfirmed: true,
+            });
+
+            const mockResponseJson = {
+                userDocExists: true,
+                hasPassword: true,
+            };
+
+            const mockFetch = jest.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve(mockResponseJson),
+            });
+            global.fetch = mockFetch;
+
+            const result = await clientAction({ request, params });
+
+            expect(acceptTeamInvitation).toHaveBeenCalledWith({
+                teamId: "team123",
+                membershipId: "mem123",
+                userId: "user123",
+                secret: "secret123",
+            });
+            expect(mockFetch).toHaveBeenCalledWith(
+                "http://localhost/team/accept-invite",
+                expect.objectContaining({
+                    method: "POST",
+                    body: expect.any(FormData),
+                }),
+            );
+
+            // Verify the FormData sent to fetch has correct intent
+            const fetchedFormData = mockFetch.mock.calls[0][1].body;
+            expect(fetchedFormData.get("_action")).toBe("check-invited-status");
+            expect(fetchedFormData.get("userId")).toBe("user123");
+
+            expect(result).toEqual({
+                success: true,
+                alreadyConfirmed: true,
+                userDocExists: true,
+                hasPassword: true,
+            });
         });
     });
 

--- a/app/routes/tests/layout.test.jsx
+++ b/app/routes/tests/layout.test.jsx
@@ -99,28 +99,51 @@ describe("Layout Route", () => {
 
         it("redirects to login if unauthorized (401)", async () => {
             isMobileUserAgent.mockReturnValue(true);
+            const unauthMockContext = {
+                get: jest.fn().mockReturnValue(null),
+            };
 
+            let thrownError;
             try {
                 await loader({
                     request: new Request("http://localhost/"),
-                    context: localMockContext,
+                    context: unauthMockContext,
                 });
             } catch (error) {
-                expect(error.url).toBe("/login");
+                thrownError = error;
             }
+
+            expect(thrownError).toBeDefined();
+            expect(thrownError.url).toBe("/login");
         });
 
         it("redirects to auth setup if profile is incomplete", async () => {
             isMobileUserAgent.mockReturnValue(true);
+            const incompleteUser = { ...mockUser, name: "User" };
+            const incompleteMockContext = {
+                get: jest.fn((ctx) => {
+                    if (
+                        (ctx && ctx.name === "userContext") ||
+                        String(ctx).includes("userContext")
+                    ) {
+                        return incompleteUser;
+                    }
+                    return {};
+                }),
+            };
 
+            let thrownError;
             try {
                 await loader({
                     request: new Request("http://localhost/"),
-                    context: localMockContext,
+                    context: incompleteMockContext,
                 });
             } catch (error) {
-                expect(error.url).toBe("/auth/setup");
+                thrownError = error;
             }
+
+            expect(thrownError).toBeDefined();
+            expect(thrownError.url).toBe("/auth/setup");
         });
 
         it("returns user data when authenticated and profile complete", async () => {

--- a/app/routes/tests/layout.test.jsx
+++ b/app/routes/tests/layout.test.jsx
@@ -4,6 +4,7 @@ import { render, screen } from "@/utils/test-utils";
 import { createSessionClient } from "@/utils/appwrite/server";
 import { isMobileUserAgent } from "@/utils/device";
 import { mockContext } from "@/utils/mockContext";
+import { getOrCreateUser } from "@/loaders/users";
 
 import Layout, { loader } from "../layout";
 
@@ -35,7 +36,7 @@ jest.mock("@/utils/device", () => ({
 }));
 
 jest.mock("@/loaders/users", () => ({
-    getUserById: jest.fn().mockResolvedValue({ agreedToTerms: true }),
+    getOrCreateUser: jest.fn().mockResolvedValue({ agreedToTerms: true }),
 }));
 
 // Mock child components to simplify layout testing
@@ -163,6 +164,36 @@ describe("Layout Route", () => {
                 isVerified: true,
                 isMobile: true,
             });
+        });
+
+        it("calls getOrCreateUser to fetch or self-heal user document", async () => {
+            isMobileUserAgent.mockReturnValue(false);
+            createSessionClient.mockResolvedValue({
+                account: {
+                    get: jest.fn().mockResolvedValue(mockUser),
+                },
+            });
+
+            const mockUserDoc = {
+                $id: "user-123",
+                userId: "user-123",
+                email: "test@example.com",
+                firstName: "Test",
+                lastName: "User",
+                status: "verified",
+            };
+            getOrCreateUser.mockResolvedValue(mockUserDoc);
+
+            const result = await loader({
+                request: new Request("http://localhost/"),
+                context: localMockContext,
+            });
+
+            expect(getOrCreateUser).toHaveBeenCalledWith({
+                userId: "user-123",
+                client: expect.any(Object),
+            });
+            expect(result.user).toEqual(expect.objectContaining(mockUserDoc));
         });
     });
 

--- a/app/routes/tests/layout.test.jsx
+++ b/app/routes/tests/layout.test.jsx
@@ -2,7 +2,6 @@ import { useNavigation } from "react-router";
 import { render, screen } from "@/utils/test-utils";
 
 import { isMobileUserAgent } from "@/utils/device";
-import { mockContext } from "@/utils/mockContext";
 import { getOrCreateUser } from "@/loaders/users";
 
 import Layout, { loader } from "../layout";

--- a/app/routes/tests/layout.test.jsx
+++ b/app/routes/tests/layout.test.jsx
@@ -1,7 +1,6 @@
 import { useNavigation } from "react-router";
 import { render, screen } from "@/utils/test-utils";
 
-import { createSessionClient } from "@/utils/appwrite/server";
 import { isMobileUserAgent } from "@/utils/device";
 import { mockContext } from "@/utils/mockContext";
 import { getOrCreateUser } from "@/loaders/users";
@@ -23,11 +22,6 @@ jest.mock("react-router", () => ({
         response.url = url;
         return response;
     }),
-}));
-
-// Mock Appwrite server utils
-jest.mock("@/utils/appwrite/server", () => ({
-    createSessionClient: jest.fn(),
 }));
 
 // Mock device utils
@@ -94,11 +88,6 @@ describe("Layout Route", () => {
     describe("loader", () => {
         it("allows access on non-mobile devices", async () => {
             isMobileUserAgent.mockReturnValue(false);
-            createSessionClient.mockResolvedValue({
-                account: {
-                    get: jest.fn().mockResolvedValue(mockUser),
-                },
-            });
 
             const result = await loader({
                 request: new Request("http://localhost/"),
@@ -110,11 +99,6 @@ describe("Layout Route", () => {
 
         it("redirects to login if unauthorized (401)", async () => {
             isMobileUserAgent.mockReturnValue(true);
-            createSessionClient.mockResolvedValue({
-                account: {
-                    get: jest.fn().mockRejectedValue({ code: 401 }),
-                },
-            });
 
             try {
                 await loader({
@@ -128,13 +112,6 @@ describe("Layout Route", () => {
 
         it("redirects to auth setup if profile is incomplete", async () => {
             isMobileUserAgent.mockReturnValue(true);
-            createSessionClient.mockResolvedValue({
-                account: {
-                    get: jest
-                        .fn()
-                        .mockResolvedValue({ ...mockUser, name: "User" }),
-                },
-            });
 
             try {
                 await loader({
@@ -148,11 +125,6 @@ describe("Layout Route", () => {
 
         it("returns user data when authenticated and profile complete", async () => {
             isMobileUserAgent.mockReturnValue(true);
-            createSessionClient.mockResolvedValue({
-                account: {
-                    get: jest.fn().mockResolvedValue(mockUser),
-                },
-            });
 
             const result = await loader({
                 request: new Request("http://localhost/"),
@@ -168,11 +140,6 @@ describe("Layout Route", () => {
 
         it("calls getOrCreateUser to fetch or self-heal user document", async () => {
             isMobileUserAgent.mockReturnValue(false);
-            createSessionClient.mockResolvedValue({
-                account: {
-                    get: jest.fn().mockResolvedValue(mockUser),
-                },
-            });
 
             const mockUserDoc = {
                 $id: "user-123",


### PR DESCRIPTION
[![Render.com PR #230 ENV](https://img.shields.io/badge/Render.com%20PR%20%23230%20ENV-blue)](https://softball-manager-react-router-pr-230.onrender.com/)

## Description
Fixes an issue where new users accepting team invites wouldn't have their Appwrite user database entry created properly, preventing them from closing the Beta Agreement modal.

## Changes
- Updates `accept-invite.jsx` to ensure users are appropriately redirected depending on profile existence.
- Adds self-healing logic in `app/loaders/users.js` and `app/actions/users.js` to recreate missing user entries from Auth data automatically.
- Implements comprehensive testing for the self-healing flows.
