### PR TITLE
feat: group achievements on profile tab and stack dates row

### DIFF
--- a/app/components/AchievementCard/AchievementCard.jsx
+++ b/app/components/AchievementCard/AchievementCard.jsx
@@ -206,9 +206,9 @@ export default function AchievementCard({
                                         justify="space-between"
                                     >
                                         {dates.length > 0 ? (
-                                            dates.map((date, idx) => (
+                                            dates.map((date) => (
                                                 <Text
-                                                    key={idx}
+                                                    key={date}
                                                     className={
                                                         classes.statValue
                                                     }

--- a/app/components/AchievementCard/AchievementCard.jsx
+++ b/app/components/AchievementCard/AchievementCard.jsx
@@ -62,6 +62,12 @@ export default function AchievementCard({
 
     const { name, description, rarity, icon } = achievement;
 
+    const dates = Array.isArray(unlockedAt)
+        ? unlockedAt
+        : unlockedAt
+          ? [unlockedAt]
+          : [];
+
     const rarityColor = rarity
         ? rarityColors[rarity.toLowerCase()] || defaultColor
         : defaultColor;
@@ -190,18 +196,35 @@ export default function AchievementCard({
                         {/* Footer: Metadata Box */}
                         {!isLocked && (
                             <Box className={classes.innerBox}>
-                                <Group justify="space-between" align="center">
+                                <Stack gap={4}>
                                     <Text className={classes.statLabel}>
-                                        Unlocked
+                                        Unlocked (x{dates.length})
                                     </Text>
-                                    <Text className={classes.statValue}>
-                                        {unlockedAt
-                                            ? DateTime.fromISO(
-                                                  unlockedAt,
-                                              ).toFormat("LLL dd, yyyy")
-                                            : "---"}
-                                    </Text>
-                                </Group>
+                                    <Group
+                                        gap="md"
+                                        wrap="wrap"
+                                        justify="space-between"
+                                    >
+                                        {dates.length > 0 ? (
+                                            dates.map((date, idx) => (
+                                                <Text
+                                                    key={idx}
+                                                    className={
+                                                        classes.statValue
+                                                    }
+                                                >
+                                                    {DateTime.fromISO(
+                                                        date,
+                                                    ).toFormat("LLL dd, yyyy")}
+                                                </Text>
+                                            ))
+                                        ) : (
+                                            <Text className={classes.statValue}>
+                                                ---
+                                            </Text>
+                                        )}
+                                    </Group>
+                                </Stack>
                             </Box>
                         )}
                     </Stack>

--- a/app/components/AchievementCard/tests/AchievementCard.test.jsx
+++ b/app/components/AchievementCard/tests/AchievementCard.test.jsx
@@ -21,7 +21,21 @@ describe("AchievementCard", () => {
         expect(
             screen.getByText("Hit 2 or more home runs in a single game."),
         ).toBeInTheDocument();
-        expect(screen.getByText("Unlocked")).toBeInTheDocument();
+        expect(screen.getByText("Unlocked (x1)")).toBeInTheDocument();
+        expect(screen.getByText("Jan 01, 2024")).toBeInTheDocument();
+    });
+
+    it("renders multiple unlock dates correctly", () => {
+        render(
+            <AchievementCard
+                achievement={mockAchievement}
+                unlockedAt={["2024-01-03T10:00:00Z", "2024-01-01T10:00:00Z"]}
+            />,
+        );
+
+        expect(screen.getByText("Multi HR Game")).toBeInTheDocument();
+        expect(screen.getByText("Unlocked (x2)")).toBeInTheDocument();
+        expect(screen.getByText("Jan 03, 2024")).toBeInTheDocument();
         expect(screen.getByText("Jan 01, 2024")).toBeInTheDocument();
     });
 

--- a/app/routes/user/components/PlayerAchievements.jsx
+++ b/app/routes/user/components/PlayerAchievements.jsx
@@ -242,7 +242,10 @@ export default function PlayerAchievements({
                                 {filtered.length > 0 ? (
                                     filtered.map((ua) => (
                                         <AchievementCard
-                                            key={ua.$id}
+                                            key={
+                                                ua.achievementId ||
+                                                ua.achievement.$id
+                                            }
                                             achievement={ua.achievement}
                                             unlockedAt={ua.unlockedDates}
                                             playerName={playerName}

--- a/app/routes/user/components/PlayerAchievements.jsx
+++ b/app/routes/user/components/PlayerAchievements.jsx
@@ -61,7 +61,32 @@ export default function PlayerAchievements({
                         );
                     }
 
-                    // Calculate stats for the dashboard from VALID achievements only
+                    // Group valid achievements by base achievement ID
+                    const groupedMap = new Map();
+                    for (const ua of validAchievements) {
+                        const achId = ua.achievementId || ua.achievement.$id;
+                        if (!groupedMap.has(achId)) {
+                            groupedMap.set(achId, {
+                                ...ua,
+                                unlockedDates: [],
+                            });
+                        }
+                        groupedMap.get(achId).unlockedDates.push(ua.$createdAt);
+                    }
+
+                    const groupedAchievements = Array.from(
+                        groupedMap.values(),
+                    ).map((group) => {
+                        // Sort dates descending (newest first)
+                        group.unlockedDates.sort(
+                            (a, b) => new Date(b) - new Date(a),
+                        );
+                        // Set $createdAt to the newest date so sortAchievements sorts correctly
+                        group.$createdAt = group.unlockedDates[0];
+                        return group;
+                    });
+
+                    // Calculate stats for the dashboard from VALID achievements (total unlocks)
                     const stats = validAchievements.reduce(
                         (acc, ua) => {
                             const rarity =
@@ -82,7 +107,7 @@ export default function PlayerAchievements({
                         },
                     );
 
-                    const sorted = sortAchievements(validAchievements);
+                    const sorted = sortAchievements(groupedAchievements);
 
                     const filtered =
                         activeFilter === "all"
@@ -219,7 +244,7 @@ export default function PlayerAchievements({
                                         <AchievementCard
                                             key={ua.$id}
                                             achievement={ua.achievement}
-                                            unlockedAt={ua.$createdAt}
+                                            unlockedAt={ua.unlockedDates}
                                             playerName={playerName}
                                             isMe={isMe}
                                         />

--- a/app/routes/user/components/tests/PlayerAchievements.test.jsx
+++ b/app/routes/user/components/tests/PlayerAchievements.test.jsx
@@ -68,7 +68,48 @@ describe("PlayerAchievements", () => {
         expect(screen.getByText("RBI King")).toBeInTheDocument();
 
         // Date check (split nodes)
-        expect(screen.getAllByText("Unlocked")).toHaveLength(2);
+        expect(screen.getAllByText(/Unlocked \(x\d+\)/i)).toHaveLength(2);
+        expect(screen.getByText("Jan 01, 2024")).toBeInTheDocument();
+    });
+
+    it("groups duplicate achievements correctly", async () => {
+        const duplicateAchievements = [
+            ...mockAchievements,
+            {
+                $id: "ua3",
+                achievementId: "ach1",
+                $createdAt: "2024-01-03T10:00:00Z",
+                achievement: {
+                    name: "Multi HR Game",
+                    description: "Hit 2 HRs",
+                    rarity: "Legendary",
+                },
+            },
+        ];
+        const promise = Promise.resolve(duplicateAchievements);
+        renderComponent(promise);
+
+        expect(await screen.findByText("Multi HR Game")).toBeInTheDocument();
+        expect(screen.getByText("RBI King")).toBeInTheDocument();
+
+        // Dashboard filter bar counters should reflect total unlocks (3 total, 2 legendary, 1 rare)
+        expect(screen.getByTestId("rarity-filter-all")).toHaveTextContent(
+            /All\s*3/i,
+        );
+        expect(screen.getByTestId("rarity-filter-legendary")).toHaveTextContent(
+            /Legendary\s*02/i,
+        );
+        expect(screen.getByTestId("rarity-filter-rare")).toHaveTextContent(
+            /Rare\s*01/i,
+        );
+
+        expect(screen.getAllByText(/Unlocked \(x\d+\)/i)).toHaveLength(2);
+
+        expect(screen.getByText("Unlocked (x2)")).toBeInTheDocument();
+        expect(screen.getByText("Unlocked (x1)")).toBeInTheDocument();
+
+        expect(screen.getByText("Jan 03, 2024")).toBeInTheDocument();
+        expect(screen.getByText("Jan 02, 2024")).toBeInTheDocument();
         expect(screen.getByText("Jan 01, 2024")).toBeInTheDocument();
     });
 


### PR DESCRIPTION
[![Render.com PR #231 ENV](https://img.shields.io/badge/Render.com%20PR%20%23231%20ENV-blue)](https://softball-manager-react-router-pr-231.onrender.com/)

### Summary
Groups duplicate achievements into a single card on the user's profile tab, showing the count of unlocks in parentheses in the label, and displaying all unlock dates in a dedicated flexed row below.

### Key Changes
- **PlayerAchievements.jsx**: Groups valid achievements by base achievement, sorting their dates descending. Keeps stats calculated from total unlock count as requested.
- **AchievementCard.jsx**: Normalizes `unlockedAt` to a dates list. Renders "Unlocked (xN)" stacked on its own row, with dates spread across the next row using `justify="space-between"`.
- **Unit Tests**: Updated `PlayerAchievements.test.jsx` and `AchievementCard.test.jsx` to test grouping logic and spacing of multiple unlock dates. All 2,146 unit tests pass.
