### PR TITLE
feat: add beta survey and responses links to settings and admin panels

### DIFF
--- a/app/routes/admin/components/ExternalToolsMenu.jsx
+++ b/app/routes/admin/components/ExternalToolsMenu.jsx
@@ -28,6 +28,11 @@ const EXTERNAL_TOOLS = [
         href: "https://joseph-gordy.sentry.io/issues/?project=4510845363814400",
         icon: IconBug,
     },
+    {
+        label: "Beta Survey Responses",
+        href: "https://docs.google.com/forms/d/1rdlF1Cx73AOz79W5q6stVBCSUIjni6zVy-0yuhein74/edit#responses",
+        icon: IconExternalLink,
+    },
 ];
 
 export function ExternalToolsMenu() {

--- a/app/routes/admin/components/tests/ExternalToolsMenu.test.jsx
+++ b/app/routes/admin/components/tests/ExternalToolsMenu.test.jsx
@@ -86,4 +86,18 @@ describe("ExternalToolsMenu", () => {
         expect(link).toHaveAttribute("target", "_blank");
         expect(link).toHaveAttribute("rel", "noopener noreferrer");
     });
+
+    it("renders the Beta Survey Responses link", async () => {
+        await openMenu();
+        const link = screen.getByRole("menuitem", {
+            name: /beta survey responses/i,
+            hidden: true,
+        });
+        expect(link).toHaveAttribute(
+            "href",
+            "https://docs.google.com/forms/d/1rdlF1Cx73AOz79W5q6stVBCSUIjni6zVy-0yuhein74/edit#responses",
+        );
+        expect(link).toHaveAttribute("target", "_blank");
+        expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
 });

--- a/app/routes/settings/components/DesktopSettingsDashboard.jsx
+++ b/app/routes/settings/components/DesktopSettingsDashboard.jsx
@@ -132,14 +132,25 @@ export default function DesktopSettingsDashboard({ actionData, teams }) {
                     icon={IconHelp}
                     iconColor="grape"
                     title="Resources & Support"
-                    description="Need help or want to review our policies?"
+                    description="Need help, want to review policies, or share feedback?"
                 >
                     <Stack gap="md">
                         <Button
                             component="a"
+                            href="https://docs.google.com/forms/d/1rdlF1Cx73AOz79W5q6stVBCSUIjni6zVy-0yuhein74/viewform"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            variant="filled"
+                            color="grape"
+                            fullWidth
+                        >
+                            Share Beta Feedback
+                        </Button>
+                        <Button
+                            component="a"
                             href="mailto:support@rostrhq.app"
                             variant="light"
-                            color="grape"
+                            color="gray"
                             fullWidth
                         >
                             Contact Support

--- a/app/routes/settings/components/SupportPanel.jsx
+++ b/app/routes/settings/components/SupportPanel.jsx
@@ -1,4 +1,5 @@
 import { Stack, Text, Button } from "@mantine/core";
+import { IconClipboardList } from "@tabler/icons-react";
 
 import { trackEvent } from "@/utils/analytics";
 
@@ -14,18 +15,34 @@ export default function SupportPanel() {
                 before reporting issues. If you are submitting a bug report,
                 please include details and screenshots if available.
             </Text>
-            <div>
+            <Stack gap="sm">
                 <Button
                     component="a"
-                    href="mailto:support@rostrhq.app"
-                    onClick={() => trackEvent("email-support")}
-                    variant="light"
+                    href="https://docs.google.com/forms/d/1rdlF1Cx73AOz79W5q6stVBCSUIjni6zVy-0yuhein74/viewform"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => trackEvent("submit-beta-feedback")}
+                    variant="filled"
+                    color="grape"
                     radius="md"
-                    justify="flex-start"
+                    leftSection={<IconClipboardList size={18} />}
                 >
-                    support@rostrhq.app
+                    Share Beta Feedback
                 </Button>
-            </div>
+                <div>
+                    <Button
+                        component="a"
+                        href="mailto:support@rostrhq.app"
+                        onClick={() => trackEvent("email-support")}
+                        variant="light"
+                        radius="md"
+                        color="gray"
+                        justify="flex-start"
+                    >
+                        support@rostrhq.app
+                    </Button>
+                </div>
+            </Stack>
         </Stack>
     );
 }

--- a/app/routes/settings/components/tests/SupportPanel.test.jsx
+++ b/app/routes/settings/components/tests/SupportPanel.test.jsx
@@ -29,4 +29,27 @@ describe("SupportPanel Component", () => {
         );
         expect(trackEvent).toHaveBeenCalledWith("email-support");
     });
+
+    it("renders beta feedback link button", () => {
+        render(<SupportPanel />);
+
+        const link = screen.getByRole("link", {
+            name: /Share Beta Feedback/i,
+        });
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveAttribute(
+            "href",
+            "https://docs.google.com/forms/d/1rdlF1Cx73AOz79W5q6stVBCSUIjni6zVy-0yuhein74/viewform",
+        );
+        expect(link).toHaveAttribute("target", "_blank");
+    });
+
+    it("tracks click on beta feedback link", () => {
+        render(<SupportPanel />);
+
+        fireEvent.click(
+            screen.getByRole("link", { name: /Share Beta Feedback/i }),
+        );
+        expect(trackEvent).toHaveBeenCalledWith("submit-beta-feedback");
+    });
 });


### PR DESCRIPTION
[![Render.com PR #232 ENV](https://img.shields.io/badge/Render.com%20PR%20%23232%20ENV-blue)](https://softball-manager-react-router-pr-232.onrender.com/)

This PR implements the beta tester survey links into the settings panels (both desktop and mobile formats) and registers the survey responses edit dashboard directly in the admin tools panel. 

### Changes
* **Settings Page (Mobile/Desktop)**: Adds a primary colored action button ("Share Beta Feedback") which links out to the live Google Form (`.../viewform`). Includes click event tracking for analytics.
* **Admin Dashboard**: Adds "Beta Survey Responses" to the dropdown of external tools which deep links to the response dashboard (`.../edit#responses`).
* **Unit Tests**: Full unit test coverage added in `SupportPanel.test.jsx` and `ExternalToolsMenu.test.jsx`. All tests passed successfully.
