### PR TITLE
feat: relocate stats to profile and add mobile dashboard quick links

### DIFF
--- a/app/components/UserHeader/UserHeader.jsx
+++ b/app/components/UserHeader/UserHeader.jsx
@@ -12,11 +12,39 @@ import {
     Text,
     Title,
     useMantineTheme,
+    Skeleton,
 } from "@mantine/core";
 
 import { IconRosetteDiscountCheckFilled } from "@tabler/icons-react";
 import classes from "./UserHeader.module.css";
 import UserStatsRow from "../UserStatsRow";
+import DeferredLoader from "@/components/DeferredLoader";
+
+function UserStatsRowSkeleton() {
+    return (
+        <Group justify="center" gap="md" mt="md" mb="sm">
+            {[1, 2, 3].map((i) => (
+                <Group
+                    key={i}
+                    gap="sm"
+                    style={{
+                        padding: "8px 12px",
+                        border: "1px solid rgba(255,255,255,0.05)",
+                        borderRadius: "8px",
+                        minWidth: 100,
+                        backgroundColor: "rgba(255,255,255,0.02)",
+                    }}
+                >
+                    <Skeleton height={28} width={28} radius="sm" />
+                    <Stack gap={4}>
+                        <Skeleton height={14} width={20} radius="xl" />
+                        <Skeleton height={10} width={35} radius="xl" />
+                    </Stack>
+                </Group>
+            ))}
+        </Group>
+    );
+}
 
 export default function UserHeader({ children, subText, stats }) {
     const context = useOutletContext();
@@ -32,6 +60,21 @@ export default function UserHeader({ children, subText, stats }) {
             { method: "post", action: "/api/resend-verification" },
         );
         setEmailSent(true);
+    };
+
+    const renderStatsRow = () => {
+        if (!stats) return null;
+        if (typeof stats.then === "function") {
+            return (
+                <DeferredLoader
+                    resolve={stats}
+                    fallback={<UserStatsRowSkeleton />}
+                >
+                    {(resolvedStats) => <UserStatsRow stats={resolvedStats} />}
+                </DeferredLoader>
+            );
+        }
+        return <UserStatsRow stats={stats} />;
     };
 
     return (
@@ -89,7 +132,7 @@ export default function UserHeader({ children, subText, stats }) {
                             justifyContent: "center",
                         }}
                     >
-                        {stats && <UserStatsRow stats={stats} />}
+                        {renderStatsRow()}
                     </Box>
 
                     <Group justify="flex-end" style={{ flex: 1 }}>
@@ -134,7 +177,7 @@ export default function UserHeader({ children, subText, stats }) {
                         )}
                     </Stack>
 
-                    {stats && <UserStatsRow stats={stats} />}
+                    {renderStatsRow()}
                 </Stack>
             )}
 

--- a/app/components/UserHeader/UserHeader.test.jsx
+++ b/app/components/UserHeader/UserHeader.test.jsx
@@ -74,4 +74,21 @@ describe("UserHeader Component", () => {
             screen.getByRole("button", { name: "Resend Verification Email" }),
         ).toBeInTheDocument();
     });
+
+    it("renders stats when stats is a promise", async () => {
+        useOutletContext.mockReturnValue({
+            user: mockUser,
+            isVerified: true,
+        });
+        useFetcher.mockReturnValue({ submit: jest.fn(), state: "idle" });
+
+        const mockStats = { awardsCount: 10, teamCount: 5, gameCount: 20 };
+        const statsPromise = Promise.resolve(mockStats);
+
+        render(<UserHeader subText="Welcome back" stats={statsPromise} />);
+
+        expect(await screen.findByText("10")).toBeInTheDocument();
+        expect(screen.getByText("5")).toBeInTheDocument();
+        expect(screen.getByText("20")).toBeInTheDocument();
+    });
 });

--- a/app/routes/dashboard/components/MobileDashboard.jsx
+++ b/app/routes/dashboard/components/MobileDashboard.jsx
@@ -196,45 +196,26 @@ export default function MobileDashboard({ teamList, openAddTeamModal }) {
             <Grid.Col span={12} pb="xl">
                 {activeTeam && (
                     <Group grow gap="xs" mb="lg">
-                        <Button
-                            component={Link}
-                            to={`/team/${activeTeamId}#seasons`}
-                            style={{
-                                backgroundColor: "var(--bg-card)",
-                                color: "var(--mantine-color-text)",
-                                border: "1px solid var(--border-card)",
-                            }}
-                            radius="md"
-                            size="sm"
-                        >
-                            Seasons
-                        </Button>
-                        <Button
-                            component={Link}
-                            to={`/team/${activeTeamId}#games`}
-                            style={{
-                                backgroundColor: "var(--bg-card)",
-                                color: "var(--mantine-color-text)",
-                                border: "1px solid var(--border-card)",
-                            }}
-                            radius="md"
-                            size="sm"
-                        >
-                            Games
-                        </Button>
-                        <Button
-                            component={Link}
-                            to={`/team/${activeTeamId}#roster`}
-                            style={{
-                                backgroundColor: "var(--bg-card)",
-                                color: "var(--mantine-color-text)",
-                                border: "1px solid var(--border-card)",
-                            }}
-                            radius="md"
-                            size="sm"
-                        >
-                            Roster
-                        </Button>
+                        {[
+                            { label: "Seasons", hash: "seasons" },
+                            { label: "Games", hash: "games" },
+                            { label: "Roster", hash: "roster" },
+                        ].map(({ label, hash }) => (
+                            <Button
+                                key={hash}
+                                component={Link}
+                                to={`/team/${activeTeamId}#${hash}`}
+                                style={{
+                                    backgroundColor: "var(--bg-card)",
+                                    color: "var(--mantine-color-text)",
+                                    border: "1px solid var(--border-card)",
+                                }}
+                                radius="md"
+                                size="sm"
+                            >
+                                {label}
+                            </Button>
+                        ))}
                     </Group>
                 )}
                 <Stack gap="md">

--- a/app/routes/dashboard/components/MobileDashboard.jsx
+++ b/app/routes/dashboard/components/MobileDashboard.jsx
@@ -194,6 +194,49 @@ export default function MobileDashboard({ teamList, openAddTeamModal }) {
             </Grid.Col>
 
             <Grid.Col span={12} pb="xl">
+                {activeTeam && (
+                    <Group grow gap="xs" mb="lg">
+                        <Button
+                            component={Link}
+                            to={`/team/${activeTeamId}#seasons`}
+                            style={{
+                                backgroundColor: "var(--bg-card)",
+                                color: "var(--mantine-color-text)",
+                                border: "1px solid var(--border-card)",
+                            }}
+                            radius="md"
+                            size="sm"
+                        >
+                            Seasons
+                        </Button>
+                        <Button
+                            component={Link}
+                            to={`/team/${activeTeamId}#games`}
+                            style={{
+                                backgroundColor: "var(--bg-card)",
+                                color: "var(--mantine-color-text)",
+                                border: "1px solid var(--border-card)",
+                            }}
+                            radius="md"
+                            size="sm"
+                        >
+                            Games
+                        </Button>
+                        <Button
+                            component={Link}
+                            to={`/team/${activeTeamId}#roster`}
+                            style={{
+                                backgroundColor: "var(--bg-card)",
+                                color: "var(--mantine-color-text)",
+                                border: "1px solid var(--border-card)",
+                            }}
+                            radius="md"
+                            size="sm"
+                        >
+                            Roster
+                        </Button>
+                    </Group>
+                )}
                 <Stack gap="md">
                     {/* Next Game (for active team) */}
                     {nextGame && Object.keys(nextGame).length > 0 && (

--- a/app/routes/dashboard/components/tests/MobileDashboard.test.jsx
+++ b/app/routes/dashboard/components/tests/MobileDashboard.test.jsx
@@ -182,4 +182,15 @@ describe("MobileDashboard Component", () => {
         renderDashboard([]);
         expect(screen.getByText("Create your first team")).toBeInTheDocument();
     });
+
+    it("renders quick link buttons (Seasons, Games, Roster) for the active team", () => {
+        renderDashboard();
+        expect(
+            screen.getByRole("link", { name: "Seasons" }),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "Games" })).toBeInTheDocument();
+        expect(
+            screen.getByRole("link", { name: "Roster" }),
+        ).toBeInTheDocument();
+    });
 });

--- a/app/routes/dashboard/dashboard.jsx
+++ b/app/routes/dashboard/dashboard.jsx
@@ -26,14 +26,13 @@ export function meta() {
 
 export async function loader({ context }) {
     const sessionClient = context.get(appwriteClientContext);
-    const { managing, playing, userId, stats } = await getUserTeams({
+    const { managing, playing, userId } = await getUserTeams({
         client: sessionClient,
         isDashboard: true,
     });
     return {
         teams: { managing, playing },
         userId,
-        stats,
     };
 }
 
@@ -104,7 +103,6 @@ export default function Dashboard({ loaderData, actionData }) {
     const userId = user?.$id;
 
     const teams = loaderData?.teams;
-    const stats = loaderData?.stats;
     const teamList = [
         ...(teams?.managing?.map((t) => ({ ...t, isManager: true })) || []),
         ...(teams?.playing?.map((t) => ({ ...t, isManager: false })) || []),

--- a/app/routes/dashboard/dashboard.jsx
+++ b/app/routes/dashboard/dashboard.jsx
@@ -132,7 +132,7 @@ export default function Dashboard({ loaderData, actionData }) {
 
     return (
         <Box px="md">
-            <UserHeader subText="Team and events summary" stats={stats}>
+            <UserHeader subText="Team and events summary">
                 <Box hiddenFrom="md">
                     <DashboardMenu userId={userId} />
                 </Box>

--- a/app/routes/team/components/MobileTeamDetails.jsx
+++ b/app/routes/team/components/MobileTeamDetails.jsx
@@ -17,12 +17,18 @@ export default function MobileTeamDetails({
     managerView,
     user,
     teamLogs,
+    tab,
+    onTabChange,
 }) {
     const { primaryColor, seasons } = team;
 
     return (
         <Box className="tour-mobile-tabs">
-            <TabsWrapper color={primaryColor} defaultValue="seasons">
+            <TabsWrapper
+                color={primaryColor}
+                value={tab}
+                onChange={onTabChange}
+            >
                 <Tabs.Tab value="roster" className="tour-mobile-tab-roster">
                     <Group gap="xs" align="center" justify="center">
                         <IconUsersGroup size={16} />

--- a/app/routes/team/components/tests/MobileTeamDetails.test.jsx
+++ b/app/routes/team/components/tests/MobileTeamDetails.test.jsx
@@ -45,4 +45,17 @@ describe("MobileTeamDetails Component", () => {
         // Since TabsWrapper defaults to seasons, check if season list is present
         expect(screen.getByTestId("season-list")).toBeInTheDocument();
     });
+
+    it("renders the active tab panel based on tab prop", () => {
+        const onTabChange = jest.fn();
+        render(
+            <MobileTeamDetails
+                {...mockProps}
+                tab="games"
+                onTabChange={onTabChange}
+            />,
+        );
+        expect(screen.getByTestId("games-list")).toBeVisible();
+        expect(screen.getByTestId("season-list")).not.toBeVisible();
+    });
 });

--- a/app/routes/team/details.jsx
+++ b/app/routes/team/details.jsx
@@ -1,4 +1,11 @@
-import { useOutletContext, redirect, Link } from "react-router";
+import { useState, useEffect } from "react";
+import {
+    useOutletContext,
+    redirect,
+    Link,
+    useLocation,
+    useNavigate,
+} from "react-router";
 import {
     Alert,
     Box,
@@ -214,8 +221,32 @@ export async function action({ request, params, context }) {
 
 export default function TeamDetails({ actionData, loaderData }) {
     const { user, isAuthenticated } = useOutletContext();
+    const location = useLocation();
+    const navigate = useNavigate();
 
     useResponseNotification(actionData);
+
+    const validTabs = ["roster", "seasons", "games"];
+    const hash = location.hash.replace(/^#/, "") || null;
+    const defaultTab = validTabs.includes(hash) ? hash : "seasons";
+    const [tab, setTab] = useState(defaultTab);
+
+    useEffect(() => {
+        const current = location?.hash?.replace(/^#/, "") || null;
+        if (current && validTabs.includes(current) && current !== tab) {
+            setTab(current);
+        }
+    }, [location.hash, tab]);
+
+    const handleTabChange = (value) => {
+        if (!value) return;
+        if (value === tab) return;
+        setTab(value);
+
+        const newHash = `#${value}`;
+        const url = `${location.pathname}${location.search}${newHash}`;
+        navigate(url, { replace: false });
+    };
 
     if (isAuthenticated === false) {
         return (
@@ -314,6 +345,8 @@ export default function TeamDetails({ actionData, loaderData }) {
                     managerView={managerView}
                     user={user}
                     teamLogs={teamLogs}
+                    tab={tab}
+                    onTabChange={handleTabChange}
                 />
             </Box>
             {managerView && (
@@ -333,4 +366,18 @@ export default function TeamDetails({ actionData, loaderData }) {
             )}
         </Container>
     );
+}
+
+export function shouldRevalidate({
+    currentUrl,
+    nextUrl,
+    defaultShouldRevalidate,
+}) {
+    if (
+        currentUrl.pathname === nextUrl.pathname &&
+        currentUrl.search === nextUrl.search
+    ) {
+        return false;
+    }
+    return defaultShouldRevalidate;
 }

--- a/app/routes/team/tests/details.test.js
+++ b/app/routes/team/tests/details.test.js
@@ -45,8 +45,8 @@ jest.mock("../components/TeamMenu", () => () => (
 jest.mock("@/components/BackButton", () => () => (
     <div data-testid="back-button" />
 ));
-jest.mock("../components/MobileTeamDetails", () => () => (
-    <div data-testid="mobile-team-details" />
+jest.mock("../components/MobileTeamDetails", () => (props) => (
+    <div data-testid="mobile-team-details" data-tab={props.tab} />
 ));
 jest.mock("../components/DesktopTeamDetails", () => () => (
     <div data-testid="desktop-team-details" />
@@ -382,8 +382,22 @@ describe("TeamDetails Route", () => {
     });
 
     describe("Component", () => {
+        const renderComponent = (
+            loaderData = mockLoaderData,
+            actionData = null,
+        ) => {
+            return render(
+                <MemoryRouter>
+                    <TeamDetails
+                        loaderData={loaderData}
+                        actionData={actionData}
+                    />
+                </MemoryRouter>,
+            );
+        };
+
         it("renders team details correctly", () => {
-            render(<TeamDetails loaderData={mockLoaderData} />);
+            renderComponent();
 
             expect(screen.getByText("Test Team")).toBeInTheDocument();
             expect(screen.getByText("Test League")).toBeInTheDocument();
@@ -393,12 +407,7 @@ describe("TeamDetails Route", () => {
 
         it("calls useResponseNotification with actionData", () => {
             const actionData = { success: true };
-            render(
-                <TeamDetails
-                    loaderData={mockLoaderData}
-                    actionData={actionData}
-                />,
-            );
+            renderComponent(mockLoaderData, actionData);
             expect(useResponseNotification).toHaveBeenCalledWith(actionData);
         });
 
@@ -407,12 +416,12 @@ describe("TeamDetails Route", () => {
                 ...mockLoaderData,
                 managerIds: ["other-user"],
             };
-            render(<TeamDetails loaderData={nonManagerLoaderData} />);
+            renderComponent(nonManagerLoaderData);
             expect(screen.queryByTestId("team-menu")).not.toBeInTheDocument();
         });
 
         it("renders Mobile and Desktop details components", () => {
-            render(<TeamDetails loaderData={mockLoaderData} />);
+            renderComponent();
 
             expect(
                 screen.getByTestId("mobile-team-details"),
@@ -423,7 +432,7 @@ describe("TeamDetails Route", () => {
         });
 
         it("renders OnboardingTour component for managers", () => {
-            render(<TeamDetails loaderData={mockLoaderData} />);
+            renderComponent();
             expect(screen.getByTestId("onboarding-tour")).toBeInTheDocument();
         });
 
@@ -432,7 +441,7 @@ describe("TeamDetails Route", () => {
                 ...mockLoaderData,
                 managerIds: ["other-user"],
             };
-            render(<TeamDetails loaderData={nonManagerLoaderData} />);
+            renderComponent(nonManagerLoaderData);
             expect(
                 screen.queryByTestId("onboarding-tour"),
             ).not.toBeInTheDocument();
@@ -443,7 +452,7 @@ describe("TeamDetails Route", () => {
                 ...mockLoaderData,
                 isArchiveView: true,
             };
-            render(<TeamDetails loaderData={archiveLoaderData} />);
+            renderComponent(archiveLoaderData);
 
             expect(
                 screen.getByText(
@@ -479,6 +488,23 @@ describe("TeamDetails Route", () => {
                 screen.getByRole("link", { name: "Log In" }),
             ).toBeInTheDocument();
         });
+
+        it("syncs the tab state based on the URL hash", () => {
+            useOutletContext.mockReturnValue({
+                user: mockUser,
+                isDesktop: false,
+                isAuthenticated: true,
+            });
+
+            render(
+                <MemoryRouter initialEntries={["/team/team1#games"]}>
+                    <TeamDetails loaderData={mockLoaderData} />
+                </MemoryRouter>,
+            );
+
+            const mobileDetails = screen.getByTestId("mobile-team-details");
+            expect(mobileDetails).toHaveAttribute("data-tab", "games");
+        });
     });
 
     describe("meta", () => {
@@ -503,6 +529,28 @@ describe("TeamDetails Route", () => {
                     content: expect.stringContaining("Thunder"),
                 }),
             );
+        });
+    });
+
+    describe("shouldRevalidate", () => {
+        it("returns false if only hash changes", () => {
+            const { shouldRevalidate } = require("../details");
+            const result = shouldRevalidate({
+                currentUrl: new URL("http://localhost/team/team1#seasons"),
+                nextUrl: new URL("http://localhost/team/team1#games"),
+                defaultShouldRevalidate: true,
+            });
+            expect(result).toBe(false);
+        });
+
+        it("returns defaultShouldRevalidate if path changes", () => {
+            const { shouldRevalidate } = require("../details");
+            const result = shouldRevalidate({
+                currentUrl: new URL("http://localhost/team/team1"),
+                nextUrl: new URL("http://localhost/team/team2"),
+                defaultShouldRevalidate: true,
+            });
+            expect(result).toBe(true);
         });
     });
 });

--- a/app/routes/user/profile.jsx
+++ b/app/routes/user/profile.jsx
@@ -65,6 +65,58 @@ export async function loader({ params, request, context }) {
 
     const sessionClient = context.get(appwriteClientContext);
 
+    const headerStatsPromise = (async () => {
+        const { Query } = await import("node-appwrite");
+        const serverModule = await import("@/utils/appwrite/server");
+        const createAdminClient =
+            serverModule.createAdminClient ||
+            serverModule.default?.createAdminClient;
+        const { listDocuments } = await import("@/utils/databases");
+
+        const [awardsResult, gameLogsResult] = await Promise.all([
+            listDocuments(
+                "awards",
+                [Query.equal("winner_user_id", userId), Query.limit(1)],
+                sessionClient,
+            ).catch(() => ({ total: 0 })),
+            listDocuments(
+                "game_logs",
+                [Query.equal("playerId", userId), Query.limit(1)],
+                sessionClient,
+            ).catch(() => ({ total: 0 })),
+        ]);
+
+        let teamCount = 0;
+        try {
+            const userAccount = await sessionClient.account
+                .get()
+                .catch(() => null);
+            if (userAccount && userAccount.$id === userId) {
+                const userTeams = await sessionClient.teams.list();
+                teamCount = userTeams.total || userTeams.teams?.length || 0;
+            } else if (createAdminClient) {
+                const adminClient = createAdminClient();
+                const rosters = await listDocuments(
+                    "season_rosters",
+                    [Query.equal("playerId", userId), Query.limit(100)],
+                    adminClient,
+                ).catch(() => ({ rows: [] }));
+                const uniqueTeamIds = new Set(
+                    rosters.rows?.map((r) => r.teamId) || [],
+                );
+                teamCount = uniqueTeamIds.size;
+            }
+        } catch (e) {
+            console.error("Error getting team count for profile stats:", e);
+        }
+
+        return {
+            awardsCount: awardsResult.total || 0,
+            gameCount: gameLogsResult.total || 0,
+            teamCount,
+        };
+    })();
+
     return {
         player: await getUserById({ userId, client: sessionClient }),
         awardsPromise: getAwardsByUserId({ userId, client: sessionClient }),
@@ -77,6 +129,7 @@ export async function loader({ params, request, context }) {
             userId,
             client: sessionClient,
         }),
+        headerStatsPromise,
         defaultTab,
     };
 }
@@ -88,6 +141,7 @@ export default function UserProfile({ loaderData }) {
         attendancePromise,
         statsPromise,
         achievementsPromise,
+        headerStatsPromise,
         player,
         defaultTab,
     } = loaderData;
@@ -138,7 +192,10 @@ export default function UserProfile({ loaderData }) {
     return (
         !!Object.keys(player).length && (
             <Box px="md" py="md">
-                <UserHeader subText="Here are your personal and player details">
+                <UserHeader
+                    subText="Here are your personal and player details"
+                    stats={headerStatsPromise}
+                >
                     {isCurrentUser && <ProfileMenu player={player} />}
                 </UserHeader>
 
@@ -174,4 +231,18 @@ export default function UserProfile({ loaderData }) {
             </Box>
         )
     );
+}
+
+export function shouldRevalidate({
+    currentUrl,
+    nextUrl,
+    defaultShouldRevalidate,
+}) {
+    if (
+        currentUrl.pathname === nextUrl.pathname &&
+        currentUrl.search === nextUrl.search
+    ) {
+        return false;
+    }
+    return defaultShouldRevalidate;
 }

--- a/app/routes/user/tests/profile.test.jsx
+++ b/app/routes/user/tests/profile.test.jsx
@@ -105,6 +105,7 @@ describe("UserProfile Route Component", () => {
                 client: expect.any(Object),
             });
             expect(result.player).toEqual(mockPlayer);
+            expect(result.headerStatsPromise).toEqual(expect.any(Promise));
             expect(result.defaultTab).toBe("stats");
         });
 
@@ -201,6 +202,28 @@ describe("UserProfile Route Component", () => {
             expect(
                 screen.queryByTestId("profile-menu"),
             ).not.toBeInTheDocument();
+        });
+    });
+
+    describe("shouldRevalidate", () => {
+        it("returns false if only hash changes", () => {
+            const { shouldRevalidate } = require("../profile");
+            const result = shouldRevalidate({
+                currentUrl: new URL("http://localhost/user/user-1#player"),
+                nextUrl: new URL("http://localhost/user/user-1#stats"),
+                defaultShouldRevalidate: true,
+            });
+            expect(result).toBe(false);
+        });
+
+        it("returns defaultShouldRevalidate if path changes", () => {
+            const { shouldRevalidate } = require("../profile");
+            const result = shouldRevalidate({
+                currentUrl: new URL("http://localhost/user/user-1"),
+                nextUrl: new URL("http://localhost/user/user-2"),
+                defaultShouldRevalidate: true,
+            });
+            expect(result).toBe(true);
         });
     });
 });


### PR DESCRIPTION
[![Render.com PR #234 ENV](https://img.shields.io/badge/Render.com%20PR%20%23234%20ENV-blue)](https://softball-manager-react-router-pr-234.onrender.com/)

This PR implements:
1. **Stats Relocation**: Relocates the user stats row (Teams, Games, Awards) from the Home/Dashboard page to the Profile page, loading them asynchronously via deferred loading and skeletons.
2. **Dashboard Quick Links**: Adds Seasons, Games, and Roster quick link buttons on the mobile dashboard. The button styling dynamically matches the game card's background (`var(--bg-card)`) and border (`var(--border-card)`) colors in both light and dark modes.
3. **Performance Optimizations**: Implements `shouldRevalidate` to prevent route loaders from re-running when only the URL hash changes, enabling instant tab transitions on the team details and profile pages.
